### PR TITLE
Align packets with `1.21.5` wiki

### DIFF
--- a/crates/valence_binary/src/bit_set.rs
+++ b/crates/valence_binary/src/bit_set.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 use std::io::Write;
 
-use crate::{Decode, Encode};
+use anyhow::ensure;
+
+use crate::{Decode, Encode, VarInt};
 
 // TODO: when better const exprs are available, compute BYTE_COUNT from
 // BIT_COUNT.
@@ -94,6 +96,81 @@ macro_rules! impl_default {
 
 impl_default!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16);
 
+/// A dynamically-sized bit set encoded as a prefixed array of 64-bit words.
+///
+/// Minecraft's protocol calls this type `BitSet`. Bits are addressed from the
+/// least-significant bit of the first word.
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct VariableBitSet(pub Vec<i64>);
+
+impl VariableBitSet {
+    pub fn bit(&self, idx: usize) -> bool {
+        let word = idx / 64;
+        let bit = idx % 64;
+
+        self.0
+            .get(word)
+            .is_some_and(|word| ((*word as u64) >> bit) & 1 == 1)
+    }
+
+    pub fn set_bit(&mut self, idx: usize, val: bool) {
+        let word = idx / 64;
+        let bit = idx % 64;
+
+        if val {
+            self.0.resize(self.0.len().max(word + 1), 0);
+            self.0[word] = (self.0[word] as u64 | (1 << bit)) as i64;
+        } else if let Some(word_value) = self.0.get_mut(word) {
+            *word_value = (*word_value as u64 & !(1 << bit)) as i64;
+
+            while self.0.last() == Some(&0) {
+                self.0.pop();
+            }
+        }
+    }
+}
+
+impl Encode for VariableBitSet {
+    fn encode(&self, mut w: impl Write) -> anyhow::Result<()> {
+        ensure!(
+            i32::try_from(self.0.len()).is_ok(),
+            "length of bit set exceeds i32::MAX (got {})",
+            self.0.len()
+        );
+
+        VarInt(self.0.len() as i32).encode(&mut w)?;
+        i64::encode_slice(&self.0, w)
+    }
+}
+
+impl Decode<'_> for VariableBitSet {
+    fn decode(r: &mut &[u8]) -> anyhow::Result<Self> {
+        Ok(Self(Vec::<i64>::decode(r)?))
+    }
+}
+
+impl fmt::Debug for VariableBitSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for VariableBitSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.is_empty() {
+            return write!(f, "0b0");
+        }
+
+        write!(f, "0b")?;
+
+        for i in (0..self.0.len() * 64).rev() {
+            write!(f, "{}", u8::from(self.bit(i)))?;
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,5 +199,19 @@ mod tests {
         bits.set_bit(5, true);
 
         assert_eq!(format!("{bits}"), "0b00000000000000100000");
+    }
+
+    #[test]
+    fn variable_bit_set_ops() {
+        let mut bits = VariableBitSet::default();
+
+        assert!(!bits.bit(70));
+        bits.set_bit(70, true);
+        assert!(bits.bit(70));
+        assert_eq!(bits.0, vec![0, 0b0100_0000]);
+
+        bits.set_bit(70, false);
+        assert!(!bits.bit(70));
+        assert!(bits.0.is_empty());
     }
 }

--- a/crates/valence_entity/src/active_status_effects.rs
+++ b/crates/valence_entity/src/active_status_effects.rs
@@ -307,7 +307,7 @@ pub struct ActiveStatusEffect {
     effect: StatusEffect,
     /// # Default Value
     /// 0
-    amplifier: u8,
+    amplifier: i32,
     /// The initial duration of the effect in ticks.
     /// If `None`, the effect is infinite.
     /// (encoded as -1 if infinite)
@@ -346,7 +346,7 @@ impl ActiveStatusEffect {
     }
 
     /// Sets the amplifier of the [`ActiveStatusEffect`].
-    pub fn with_amplifier(mut self, amplifier: u8) -> Self {
+    pub fn with_amplifier(mut self, amplifier: i32) -> Self {
         self.amplifier = amplifier;
         self
     }
@@ -398,7 +398,7 @@ impl ActiveStatusEffect {
     }
 
     /// Returns the amplifier of the [`ActiveStatusEffect`].
-    pub fn amplifier(&self) -> u8 {
+    pub fn amplifier(&self) -> i32 {
         self.amplifier
     }
 

--- a/crates/valence_entity/src/query.rs
+++ b/crates/valence_entity/src/query.rs
@@ -5,7 +5,6 @@ use bevy_ecs::query::QueryData;
 use bevy_ecs::world::Ref;
 use valence_math::DVec3;
 use valence_protocol::encode::WritePacket;
-use valence_protocol::movement_flags::MovementFlags;
 use valence_protocol::packets::play::{
     AddEntityS2c, AnimateS2c, EntityEventS2c, EntityPositionSyncS2c, MoveEntityPosRotS2c,
     MoveEntityPosS2c, MoveEntityRotS2c, RotateHeadS2c, SetEntityDataS2c, SetEntityMotionS2c,
@@ -97,8 +96,7 @@ impl UpdateEntityQueryItem<'_> {
                 delta: (position_delta * 4096.0).to_array().map(|v| v as i16),
                 yaw: ByteAngle::from_degrees(self.look.yaw),
                 pitch: ByteAngle::from_degrees(self.look.pitch),
-                // FIXME: add missing pushing_against_wall
-                flags: MovementFlags::new().with_on_ground(self.on_ground.0),
+                on_ground: self.on_ground.0,
             });
         } else {
             if changed_position && !needs_teleport {

--- a/crates/valence_network/src/connect.rs
+++ b/crates/valence_network/src/connect.rs
@@ -638,7 +638,7 @@ async fn login_velocity(
 
     let data = &plugin_response
         .data
-        // .context("missing plugin response data")?
+        .context("missing plugin response data")?
         .0[1..];
 
     ensure!(data.len() >= 32, "invalid plugin response data length");

--- a/crates/valence_protocol/src/lib.rs
+++ b/crates/valence_protocol/src/lib.rs
@@ -70,7 +70,7 @@ pub use {
 };
 
 /// The maximum number of bytes in a single Minecraft packet.
-pub const MAX_PACKET_SIZE: i32 = 2097152;
+pub const MAX_PACKET_SIZE: i32 = 2_i32.pow(21) - 1; // (the maximum that can be sent in a 3-byte VarInt)
 
 /// The Minecraft protocol version this library currently targets.
 pub const PROTOCOL_VERSION: i32 = 770;

--- a/crates/valence_protocol/src/lib.rs
+++ b/crates/valence_protocol/src/lib.rs
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 pub use sound::Sound;
 pub use text::{JsonText, Text};
 pub use valence_binary::array::FixedArray;
-pub use valence_binary::bit_set::FixedBitSet;
+pub use valence_binary::bit_set::{FixedBitSet, VariableBitSet};
 pub use valence_binary::byte_angle::ByteAngle;
 use valence_binary::Encode;
 pub use valence_binary::{

--- a/crates/valence_protocol/src/packets/configuration/cookie_response_c2s.rs
+++ b/crates/valence_protocol/src/packets/configuration/cookie_response_c2s.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use valence_binary::{Decode, Encode};
+use valence_binary::{Bounded, Decode, Encode};
 use valence_ident::Ident;
 
 use crate::{Packet, PacketState};
@@ -11,5 +11,5 @@ use crate::{Packet, PacketState};
 /// [`CookieRequestS2c`](crate::packets::configuration::CookieRequestS2c) packet.
 pub struct CookieResponseC2s<'a> {
     pub key: Ident<Cow<'a, str>>,
-    pub payload: Option<Cow<'a, [u8]>>,
+    pub payload: Option<Bounded<&'a [u8], 5120>>,
 }

--- a/crates/valence_protocol/src/packets/configuration/cookie_response_c2s.rs
+++ b/crates/valence_protocol/src/packets/configuration/cookie_response_c2s.rs
@@ -7,7 +7,8 @@ use crate::{Packet, PacketState};
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
 #[packet(state = PacketState::Configuration)]
-/// Response to a cookie request from the server.
+/// Sent by the client to the server to respond to a
+/// [`CookieRequestS2c`](crate::packets::configuration::CookieRequestS2c) packet.
 pub struct CookieResponseC2s<'a> {
     pub key: Ident<Cow<'a, str>>,
     pub payload: Option<Cow<'a, [u8]>>,

--- a/crates/valence_protocol/src/packets/configuration/keep_alive_c2s.rs
+++ b/crates/valence_protocol/src/packets/configuration/keep_alive_c2s.rs
@@ -9,4 +9,4 @@ use crate::{Packet, PacketState};
 /// The id is the same as the one sent by the server. if a client does not
 /// respond to a `KeepAliveS2c` packet within 15 seconds, the server should
 /// disconnect the client.
-pub struct KeepAliveC2s(pub i32);
+pub struct KeepAliveC2s(pub i64);

--- a/crates/valence_protocol/src/packets/configuration/resource_pack_push_s2c.rs
+++ b/crates/valence_protocol/src/packets/configuration/resource_pack_push_s2c.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use uuid::Uuid;
 use valence_binary::{Bounded, Decode, Encode, TextComponent};
 
@@ -9,5 +10,6 @@ pub struct ResourcePackPushS2c<'a> {
     pub uuid: Uuid,
     pub url: Bounded<&'a str, 32767>,
     pub hash: Bounded<&'a str, 40>,
-    pub prompt_message: Option<TextComponent>,
+    pub forced: bool,
+    pub prompt_message: Option<Cow<'a, TextComponent>>,
 }

--- a/crates/valence_protocol/src/packets/configuration/server_links_s2c.rs
+++ b/crates/valence_protocol/src/packets/configuration/server_links_s2c.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::io::Write;
 
 use valence_binary::{Decode, Encode, TextComponent};
 
@@ -16,13 +17,38 @@ pub struct ServerLink<'a> {
     pub url: Cow<'a, str>,
 }
 
-#[derive(Clone, Debug, Encode, Decode)]
+#[derive(Clone, Debug)]
 pub enum ServerLinkEnum {
     BuiltIn(BuiltInLinkType),
     CustomText(TextComponent),
 }
 
-#[derive(Clone, Debug, Encode, Decode)]
+impl Encode for ServerLinkEnum {
+    fn encode(&self, mut w: impl Write) -> anyhow::Result<()> {
+        match self {
+            ServerLinkEnum::BuiltIn(label) => {
+                true.encode(&mut w)?;
+                label.encode(w)
+            }
+            ServerLinkEnum::CustomText(label) => {
+                false.encode(&mut w)?;
+                label.encode(w)
+            }
+        }
+    }
+}
+
+impl Decode<'_> for ServerLinkEnum {
+    fn decode(r: &mut &[u8]) -> anyhow::Result<Self> {
+        Ok(if bool::decode(r)? {
+            ServerLinkEnum::BuiltIn(Decode::decode(r)?)
+        } else {
+            ServerLinkEnum::CustomText(Decode::decode(r)?)
+        })
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Encode, Decode)]
 pub enum BuiltInLinkType {
     BugReport,
     CommunityGuidelines,

--- a/crates/valence_protocol/src/packets/configuration/store_cookie_s2c.rs
+++ b/crates/valence_protocol/src/packets/configuration/store_cookie_s2c.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use valence_binary::{Decode, Encode};
+use valence_binary::{Bounded, Decode, Encode};
 use valence_ident::Ident;
 
 use crate::{Packet, PacketState};
@@ -10,5 +10,5 @@ use crate::{Packet, PacketState};
 /// Stores a cookie on the client
 pub struct StoreCookieS2c<'a> {
     pub key: Ident<Cow<'a, str>>,
-    pub payload: Cow<'a, [u8]>,
+    pub payload: Bounded<&'a [u8], 5120>,
 }

--- a/crates/valence_protocol/src/packets/configuration/transfer_s2c.rs
+++ b/crates/valence_protocol/src/packets/configuration/transfer_s2c.rs
@@ -1,13 +1,9 @@
-use std::borrow::Cow;
-
-use valence_binary::{Decode, Encode, VarInt};
-use valence_ident::Ident;
-
 use crate::{Packet, PacketState};
+use valence_binary::{Bounded, Decode, Encode, VarInt};
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
 #[packet(state = PacketState::Configuration)]
 pub struct TransferS2c<'a> {
-    pub host: Ident<Cow<'a, str>>,
+    pub host: Bounded<&'a str, 32767>,
     pub port: VarInt,
 }

--- a/crates/valence_protocol/src/packets/login/cookie_response_c2s.rs
+++ b/crates/valence_protocol/src/packets/login/cookie_response_c2s.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use valence_binary::{Decode, Encode};
+use valence_binary::{Bounded, Decode, Encode};
 use valence_ident::Ident;
 
 use crate::{Packet, PacketState};
@@ -11,5 +11,5 @@ use crate::{Packet, PacketState};
 /// [`CookieRequestS2c`](crate::packets::login::CookieRequestS2c) packet.
 pub struct CookieResponseC2s<'a> {
     pub key: Ident<Cow<'a, str>>,
-    pub payload: Option<Cow<'a, [u8]>>,
+    pub payload: Option<Bounded<&'a [u8], 5120>>,
 }

--- a/crates/valence_protocol/src/packets/login/cookie_response_c2s.rs
+++ b/crates/valence_protocol/src/packets/login/cookie_response_c2s.rs
@@ -11,6 +11,5 @@ use crate::{Packet, PacketState};
 /// [`CookieRequestS2c`](crate::packets::login::CookieRequestS2c) packet.
 pub struct CookieResponseC2s<'a> {
     pub key: Ident<Cow<'a, str>>,
-    pub has_payload: bool,
     pub payload: Option<Cow<'a, [u8]>>,
 }

--- a/crates/valence_protocol/src/packets/login/custom_query_answer_c2s.rs
+++ b/crates/valence_protocol/src/packets/login/custom_query_answer_c2s.rs
@@ -8,5 +8,5 @@ use crate::{Packet, PacketState};
 /// [`CustomQueryS2c`](crate::packets::login::CustomQueryS2c) packet.
 pub struct CustomQueryAnswerC2s<'a> {
     pub message_id: VarInt,
-    pub data: Bounded<RawBytes<'a>, 1048576>,
+    pub data: Option<Bounded<RawBytes<'a>, 1048576>>,
 }

--- a/crates/valence_protocol/src/packets/login/login_finished_s2c.rs
+++ b/crates/valence_protocol/src/packets/login/login_finished_s2c.rs
@@ -16,6 +16,4 @@ pub struct LoginFinishedS2c<'a> {
     pub uuid: Uuid,
     pub username: Bounded<&'a str, 16>,
     pub properties: Cow<'a, [Property<&'a str>]>,
-    // This field was temporarily added in 1.20.5, it will be removed in 1.21.2
-    // pub strict_error_handling: bool,
 }

--- a/crates/valence_protocol/src/packets/play/chat_command_signed_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/chat_command_signed_c2s.rs
@@ -1,23 +1,23 @@
-use valence_binary::{Bounded, Decode, Encode, RawBytes, VarInt};
+use valence_binary::{Bounded, Decode, Encode, VarInt};
 
 use crate::{FixedBitSet, Packet};
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
 pub struct ChatCommandSignedC2s<'a> {
-    pub command: Bounded<&'a str, 256>,
-    pub timestamp: u64,
-    pub salt: u64,
+    pub command: Bounded<&'a str, 32767>,
+    pub timestamp: i64,
+    pub salt: i64,
     pub argument_signatures: Bounded<Vec<CommandArgumentSignature<'a>>, 8>,
     pub message_count: VarInt,
     //// This is a bitset of 20; each bit represents one
     //// of the last 20 messages received and whether or not
     //// the message was acknowledged by the client
     pub acknowledgement: FixedBitSet<20, 3>,
-    pub checksum: u8,
+    pub checksum: i8,
 }
 
 #[derive(Copy, Clone, Debug, Encode, Decode)]
 pub struct CommandArgumentSignature<'a> {
     pub argument_name: Bounded<&'a str, 16>,
-    pub signature: Bounded<RawBytes<'a>, 256>,
+    pub signature: &'a [u8; 256],
 }

--- a/crates/valence_protocol/src/packets/play/container_button_click_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/container_button_click_c2s.rs
@@ -1,9 +1,9 @@
-use valence_binary::{Decode, Encode};
+use valence_binary::{Decode, Encode, VarInt};
 
 use crate::Packet;
 
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
 pub struct ContainerButtonClickC2s {
-    pub window_id: i8,
-    pub button_id: i8,
+    pub window_id: VarInt,
+    pub button_id: VarInt,
 }

--- a/crates/valence_protocol/src/packets/play/cookie_response_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/cookie_response_c2s.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use valence_binary::{Decode, Encode};
+use valence_binary::{Bounded, Decode, Encode};
 use valence_ident::Ident;
 
 use crate::Packet;
@@ -10,5 +10,5 @@ use crate::Packet;
 /// [`CookieRequestS2c`](crate::packets::play::CookieRequestS2c) packet.
 pub struct CookieResponseC2s<'a> {
     pub key: Ident<Cow<'a, str>>,
-    pub payload: Option<Cow<'a, [u8]>>,
+    pub payload: Option<Bounded<&'a [u8], 5120>>,
 }

--- a/crates/valence_protocol/src/packets/play/cookie_response_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/cookie_response_c2s.rs
@@ -6,7 +6,8 @@ use valence_ident::Ident;
 use crate::Packet;
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
-/// Response to a cookie request from the server.
+/// Sent by the client to the server to respond to a
+/// [`CookieRequestS2c`](crate::packets::play::CookieRequestS2c) packet.
 pub struct CookieResponseC2s<'a> {
     pub key: Ident<Cow<'a, str>>,
     pub payload: Option<Cow<'a, [u8]>>,

--- a/crates/valence_protocol/src/packets/play/disguised_chat_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/disguised_chat_s2c.rs
@@ -1,13 +1,14 @@
 use std::borrow::Cow;
 
-use valence_binary::{Decode, Encode, TextComponent, VarInt};
+use valence_binary::{Decode, Encode, TextComponent};
 
+use super::player_chat_s2c::ChatType;
 use crate::Packet;
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
 pub struct DisguisedChatS2c<'a> {
     pub message: Cow<'a, TextComponent>,
-    pub chat_type: VarInt,
+    pub chat_type: ChatType<'a>,
     pub sender_name: Cow<'a, TextComponent>,
     pub target_name: Option<Cow<'a, TextComponent>>,
 }

--- a/crates/valence_protocol/src/packets/play/horse_screen_open_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/horse_screen_open_s2c.rs
@@ -4,7 +4,7 @@ use crate::Packet;
 
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
 pub struct HorseScreenOpenS2c {
-    pub window_id: u8,
+    pub window_id: VarInt,
     pub slot_count: VarInt,
     pub entity_id: i32,
 }

--- a/crates/valence_protocol/src/packets/play/keep_alive_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/keep_alive_c2s.rs
@@ -4,5 +4,5 @@ use crate::Packet;
 
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
 pub struct KeepAliveC2s {
-    pub id: u64,
+    pub id: i64,
 }

--- a/crates/valence_protocol/src/packets/play/keep_alive_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/keep_alive_s2c.rs
@@ -4,5 +4,5 @@ use crate::Packet;
 
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
 pub struct KeepAliveS2c {
-    pub id: u64,
+    pub id: i64,
 }

--- a/crates/valence_protocol/src/packets/play/map_item_data_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/map_item_data_s2c.rs
@@ -53,6 +53,14 @@ pub enum IconType {
     RedBanner,
     BlackBanner,
     TreasureMarker,
+    DesertVillage,
+    PlainsVillage,
+    SavannaVillage,
+    SnowyVillage,
+    TaigaVillage,
+    JungleTemple,
+    SwampHut,
+    TrialChambers,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encode)]

--- a/crates/valence_protocol/src/packets/play/move_entity_pos_rot_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/move_entity_pos_rot_s2c.rs
@@ -1,6 +1,5 @@
 use valence_binary::{Decode, Encode, VarInt};
 
-use crate::movement_flags::MovementFlags;
 use crate::{ByteAngle, Packet};
 
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
@@ -9,5 +8,5 @@ pub struct MoveEntityPosRotS2c {
     pub delta: [i16; 3],
     pub yaw: ByteAngle,
     pub pitch: ByteAngle,
-    pub flags: MovementFlags,
+    pub on_ground: bool,
 }

--- a/crates/valence_protocol/src/packets/play/move_vehicle_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/move_vehicle_c2s.rs
@@ -8,4 +8,5 @@ pub struct MoveVehicleC2s {
     pub position: DVec3,
     pub yaw: f32,
     pub pitch: f32,
+    pub on_ground: bool,
 }

--- a/crates/valence_protocol/src/packets/play/place_ghost_recipe_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/place_ghost_recipe_s2c.rs
@@ -1,9 +1,10 @@
 use valence_binary::{Decode, Encode, VarInt};
 
+use super::recipe_book_add_s2c::RecipeDisplay;
 use crate::Packet;
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
-pub struct PlaceGhostRecipeS2c {
+pub struct PlaceGhostRecipeS2c<'a> {
     pub window_id: VarInt,
-    pub recipe_display: VarInt,
+    pub recipe_display: RecipeDisplay<'a>,
 }

--- a/crates/valence_protocol/src/packets/play/place_recipe_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/place_recipe_c2s.rs
@@ -4,7 +4,7 @@ use crate::Packet;
 
 #[derive(Clone, Debug, Encode, Decode, Packet)]
 pub struct PlaceRecipeC2s {
-    pub window_id: i8,
+    pub window_id: VarInt,
     pub recipe: VarInt,
     pub make_all: bool,
 }

--- a/crates/valence_protocol/src/packets/play/player_chat_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/player_chat_s2c.rs
@@ -8,6 +8,7 @@ use crate::Packet;
 
 #[derive(Clone, PartialEq, Debug, Packet)]
 pub struct PlayerChatS2c<'a> {
+    pub global_index: VarInt,
     pub sender: Uuid,
     pub index: VarInt,
     pub message_signature: Option<&'a [u8; 256]>,
@@ -32,6 +33,7 @@ pub enum MessageFilterType {
 
 impl Encode for PlayerChatS2c<'_> {
     fn encode(&self, mut w: impl Write) -> anyhow::Result<()> {
+        self.global_index.encode(&mut w)?;
         self.sender.encode(&mut w)?;
         self.index.encode(&mut w)?;
         self.message_signature.encode(&mut w)?;
@@ -60,6 +62,7 @@ impl Encode for PlayerChatS2c<'_> {
 
 impl<'a> Decode<'a> for PlayerChatS2c<'a> {
     fn decode(r: &mut &'a [u8]) -> anyhow::Result<Self> {
+        let global_index = VarInt::decode(r)?;
         let sender = Uuid::decode(r)?;
         let index = VarInt::decode(r)?;
         let message_signature = Option::<&'a [u8; 256]>::decode(r)?;
@@ -80,6 +83,7 @@ impl<'a> Decode<'a> for PlayerChatS2c<'a> {
         let network_target_name = Option::<Cow<'a, TextComponent>>::decode(r)?;
 
         Ok(Self {
+            global_index,
             sender,
             index,
             message_signature,

--- a/crates/valence_protocol/src/packets/play/player_chat_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/player_chat_s2c.rs
@@ -2,9 +2,10 @@ use std::borrow::Cow;
 use std::io::Write;
 
 use uuid::Uuid;
-use valence_binary::{Bounded, Decode, Encode, TextComponent, VarInt};
+use valence_binary::{Bounded, Decode, Encode, IdOr, TextComponent, VarInt};
+use valence_nbt::Compound;
 
-use crate::Packet;
+use crate::{Packet, VariableBitSet};
 
 #[derive(Clone, PartialEq, Debug, Packet)]
 pub struct PlayerChatS2c<'a> {
@@ -18,10 +19,32 @@ pub struct PlayerChatS2c<'a> {
     pub previous_messages: Vec<MessageSignature<'a>>,
     pub unsigned_content: Option<Cow<'a, TextComponent>>,
     pub filter_type: MessageFilterType,
-    pub filter_type_bits: Option<u8>,
-    pub chat_type: VarInt,
+    pub filter_type_bits: Option<VariableBitSet>,
+    pub chat_type: ChatType<'a>,
     pub network_name: Cow<'a, TextComponent>,
     pub network_target_name: Option<Cow<'a, TextComponent>>,
+}
+
+pub type ChatType<'a> = IdOr<DirectChatType<'a>>;
+
+#[derive(Clone, PartialEq, Debug, Encode, Decode)]
+pub struct DirectChatType<'a> {
+    pub chat: ChatTypeDecoration<'a>,
+    pub narration: ChatTypeDecoration<'a>,
+}
+
+#[derive(Clone, PartialEq, Debug, Encode, Decode)]
+pub struct ChatTypeDecoration<'a> {
+    pub translation_key: Cow<'a, str>,
+    pub parameters: Vec<ChatTypeParameter>,
+    pub style: Compound,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
+pub enum ChatTypeParameter {
+    Sender,
+    Target,
+    Content,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
@@ -45,11 +68,10 @@ impl Encode for PlayerChatS2c<'_> {
         self.filter_type.encode(&mut w)?;
 
         if self.filter_type == MessageFilterType::PartiallyFiltered {
-            match self.filter_type_bits {
-                // Filler data
-                None => 0_u8.encode(&mut w)?,
-                Some(bits) => bits.encode(&mut w)?,
-            }
+            self.filter_type_bits
+                .clone()
+                .unwrap_or_default()
+                .encode(&mut w)?;
         }
 
         self.chat_type.encode(&mut w)?;
@@ -74,11 +96,11 @@ impl<'a> Decode<'a> for PlayerChatS2c<'a> {
         let filter_type = MessageFilterType::decode(r)?;
 
         let filter_type_bits = match filter_type {
-            MessageFilterType::PartiallyFiltered => Some(u8::decode(r)?),
+            MessageFilterType::PartiallyFiltered => Some(VariableBitSet::decode(r)?),
             _ => None,
         };
 
-        let chat_type = VarInt::decode(r)?;
+        let chat_type = ChatType::decode(r)?;
         let network_name = <Cow<'a, TextComponent>>::decode(r)?;
         let network_target_name = Option::<Cow<'a, TextComponent>>::decode(r)?;
 

--- a/crates/valence_protocol/src/packets/play/set_objective_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/set_objective_s2c.rs
@@ -25,12 +25,6 @@ pub enum ObjectiveMode<'a> {
         render_type: ObjectiveRenderType,
         number_format: Option<NumberFormat<'a>>,
     },
-    AddEntitiesToTeam {
-        entities: Vec<String>,
-    },
-    RemoveEntitiesFromTeam {
-        entities: Vec<String>,
-    },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode, Component, Default)]

--- a/crates/valence_protocol/src/packets/play/set_player_team_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/set_player_team_s2c.rs
@@ -59,20 +59,8 @@ impl Encode for Mode<'_> {
                 0_i8.encode(&mut w)?;
                 team_display_name.encode(&mut w)?;
                 friendly_flags.encode(&mut w)?;
-                match name_tag_visibility {
-                    NameTagVisibility::Always => "always",
-                    NameTagVisibility::Never => "never",
-                    NameTagVisibility::HideForOtherTeams => "hideForOtherTeams",
-                    NameTagVisibility::HideForOwnTeam => "hideForOwnTeam",
-                }
-                .encode(&mut w)?;
-                match collision_rule {
-                    CollisionRule::Always => "always",
-                    CollisionRule::Never => "never",
-                    CollisionRule::PushOtherTeams => "pushOtherTeams",
-                    CollisionRule::PushOwnTeam => "pushOwnTeam",
-                }
-                .encode(&mut w)?;
+                name_tag_visibility.encode(&mut w)?;
+                collision_rule.encode(&mut w)?;
                 team_color.encode(&mut w)?;
                 team_prefix.encode(&mut w)?;
                 team_suffix.encode(&mut w)?;
@@ -91,20 +79,8 @@ impl Encode for Mode<'_> {
                 2_i8.encode(&mut w)?;
                 team_display_name.encode(&mut w)?;
                 friendly_flags.encode(&mut w)?;
-                match name_tag_visibility {
-                    NameTagVisibility::Always => "always",
-                    NameTagVisibility::Never => "never",
-                    NameTagVisibility::HideForOtherTeams => "hideForOtherTeams",
-                    NameTagVisibility::HideForOwnTeam => "hideForOwnTeam",
-                }
-                .encode(&mut w)?;
-                match collision_rule {
-                    CollisionRule::Always => "always",
-                    CollisionRule::Never => "never",
-                    CollisionRule::PushOtherTeams => "pushOtherTeams",
-                    CollisionRule::PushOwnTeam => "pushOwnTeam",
-                }
-                .encode(&mut w)?;
+                name_tag_visibility.encode(&mut w)?;
+                collision_rule.encode(&mut w)?;
                 team_color.encode(&mut w)?;
                 team_prefix.encode(&mut w)?;
                 team_suffix.encode(&mut w)?;
@@ -128,20 +104,8 @@ impl<'a> Decode<'a> for Mode<'a> {
             0 => Self::CreateTeam {
                 team_display_name: Decode::decode(r)?,
                 friendly_flags: Decode::decode(r)?,
-                name_tag_visibility: match <&str>::decode(r)? {
-                    "always" => NameTagVisibility::Always,
-                    "never" => NameTagVisibility::Never,
-                    "hideForOtherTeams" => NameTagVisibility::HideForOtherTeams,
-                    "hideForOwnTeam" => NameTagVisibility::HideForOwnTeam,
-                    other => bail!("unknown name tag visibility type \"{other}\""),
-                },
-                collision_rule: match <&str>::decode(r)? {
-                    "always" => CollisionRule::Always,
-                    "never" => CollisionRule::Never,
-                    "pushOtherTeams" => CollisionRule::PushOtherTeams,
-                    "pushOwnTeam" => CollisionRule::PushOwnTeam,
-                    other => bail!("unknown collision rule type \"{other}\""),
-                },
+                name_tag_visibility: Decode::decode(r)?,
+                collision_rule: Decode::decode(r)?,
                 team_color: Decode::decode(r)?,
                 team_prefix: Decode::decode(r)?,
                 team_suffix: Decode::decode(r)?,
@@ -151,20 +115,8 @@ impl<'a> Decode<'a> for Mode<'a> {
             2 => Self::UpdateTeamInfo {
                 team_display_name: Decode::decode(r)?,
                 friendly_flags: Decode::decode(r)?,
-                name_tag_visibility: match <&str>::decode(r)? {
-                    "always" => NameTagVisibility::Always,
-                    "never" => NameTagVisibility::Never,
-                    "hideForOtherTeams" => NameTagVisibility::HideForOtherTeams,
-                    "hideForOwnTeam" => NameTagVisibility::HideForOwnTeam,
-                    other => bail!("unknown name tag visibility type \"{other}\""),
-                },
-                collision_rule: match <&str>::decode(r)? {
-                    "always" => CollisionRule::Always,
-                    "never" => CollisionRule::Never,
-                    "pushOtherTeams" => CollisionRule::PushOtherTeams,
-                    "pushOwnTeam" => CollisionRule::PushOwnTeam,
-                    other => bail!("unknown collision rule type \"{other}\""),
-                },
+                name_tag_visibility: Decode::decode(r)?,
+                collision_rule: Decode::decode(r)?,
                 team_color: Decode::decode(r)?,
                 team_prefix: Decode::decode(r)?,
                 team_suffix: Decode::decode(r)?,
@@ -189,15 +141,15 @@ pub struct TeamFlags {
     _pad: u8,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
 pub enum NameTagVisibility {
     Always,
     Never,
     HideForOtherTeams,
-    HideForOwnTeam,
+    HideForOwnTeams,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode)]
 pub enum CollisionRule {
     Always,
     Never,

--- a/crates/valence_protocol/src/packets/play/set_player_team_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/set_player_team_s2c.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
-use std::io::Write;
 
-use anyhow::bail;
 use bitfield_struct::bitfield;
 use valence_binary::{Decode, Encode, TextComponent};
 
@@ -13,7 +11,7 @@ pub struct SetPlayerTeamS2c<'a> {
     pub mode: Mode<'a>,
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Encode, Decode)]
 pub enum Mode<'a> {
     CreateTeam {
         team_display_name: Cow<'a, TextComponent>,
@@ -41,95 +39,6 @@ pub enum Mode<'a> {
     RemoveEntities {
         entities: Vec<&'a str>,
     },
-}
-
-impl Encode for Mode<'_> {
-    fn encode(&self, mut w: impl Write) -> anyhow::Result<()> {
-        match self {
-            Mode::CreateTeam {
-                team_display_name,
-                friendly_flags,
-                name_tag_visibility,
-                collision_rule,
-                team_color,
-                team_prefix,
-                team_suffix,
-                entities,
-            } => {
-                0_i8.encode(&mut w)?;
-                team_display_name.encode(&mut w)?;
-                friendly_flags.encode(&mut w)?;
-                name_tag_visibility.encode(&mut w)?;
-                collision_rule.encode(&mut w)?;
-                team_color.encode(&mut w)?;
-                team_prefix.encode(&mut w)?;
-                team_suffix.encode(&mut w)?;
-                entities.encode(&mut w)?;
-            }
-            Mode::RemoveTeam => 1_i8.encode(&mut w)?,
-            Mode::UpdateTeamInfo {
-                team_display_name,
-                friendly_flags,
-                name_tag_visibility,
-                collision_rule,
-                team_color,
-                team_prefix,
-                team_suffix,
-            } => {
-                2_i8.encode(&mut w)?;
-                team_display_name.encode(&mut w)?;
-                friendly_flags.encode(&mut w)?;
-                name_tag_visibility.encode(&mut w)?;
-                collision_rule.encode(&mut w)?;
-                team_color.encode(&mut w)?;
-                team_prefix.encode(&mut w)?;
-                team_suffix.encode(&mut w)?;
-            }
-            Mode::AddEntities { entities } => {
-                3_i8.encode(&mut w)?;
-                entities.encode(&mut w)?;
-            }
-            Mode::RemoveEntities { entities } => {
-                4_i8.encode(&mut w)?;
-                entities.encode(&mut w)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-impl<'a> Decode<'a> for Mode<'a> {
-    fn decode(r: &mut &'a [u8]) -> anyhow::Result<Self> {
-        Ok(match i8::decode(r)? {
-            0 => Self::CreateTeam {
-                team_display_name: Decode::decode(r)?,
-                friendly_flags: Decode::decode(r)?,
-                name_tag_visibility: Decode::decode(r)?,
-                collision_rule: Decode::decode(r)?,
-                team_color: Decode::decode(r)?,
-                team_prefix: Decode::decode(r)?,
-                team_suffix: Decode::decode(r)?,
-                entities: Decode::decode(r)?,
-            },
-            1 => Self::RemoveTeam,
-            2 => Self::UpdateTeamInfo {
-                team_display_name: Decode::decode(r)?,
-                friendly_flags: Decode::decode(r)?,
-                name_tag_visibility: Decode::decode(r)?,
-                collision_rule: Decode::decode(r)?,
-                team_color: Decode::decode(r)?,
-                team_prefix: Decode::decode(r)?,
-                team_suffix: Decode::decode(r)?,
-            },
-            3 => Self::AddEntities {
-                entities: Decode::decode(r)?,
-            },
-            4 => Self::RemoveEntities {
-                entities: Decode::decode(r)?,
-            },
-            n => bail!("unknown update teams action of {n}"),
-        })
-    }
 }
 
 #[bitfield(u8)]

--- a/crates/valence_protocol/src/packets/play/set_structure_block_c2s.rs
+++ b/crates/valence_protocol/src/packets/play/set_structure_block_c2s.rs
@@ -56,6 +56,7 @@ pub struct Flags {
     pub ignore_entities: bool,
     pub show_air: bool,
     pub show_bounding_box: bool,
-    #[bits(5)]
+    pub strict_placement: bool,
+    #[bits(4)]
     _pad: u8,
 }

--- a/crates/valence_protocol/src/packets/play/store_cookie_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/store_cookie_s2c.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use valence_binary::{Decode, Encode};
+use valence_binary::{Bounded, Decode, Encode};
 use valence_ident::Ident;
 
 use crate::Packet;
@@ -9,5 +9,5 @@ use crate::Packet;
 /// Stores a cookie on the client
 pub struct StoreCookieS2c<'a> {
     pub key: Ident<Cow<'a, str>>,
-    pub payload: Cow<'a, [u8]>,
+    pub payload: Bounded<&'a [u8], 5120>,
 }

--- a/crates/valence_protocol/src/packets/play/teleport_entity_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/teleport_entity_s2c.rs
@@ -2,15 +2,15 @@ use valence_binary::{Decode, Encode, VarInt};
 use valence_math::DVec3;
 
 use crate::packets::play::player_position_s2c::TeleportRelativeFlags;
-use crate::{ByteAngle, Packet};
+use crate::Packet;
 
 #[derive(Copy, Clone, Debug, Encode, Decode, Packet)]
 pub struct TeleportEntityS2c {
     pub entity_id: VarInt,
     pub position: DVec3,
     pub velocity: DVec3,
-    pub yaw: ByteAngle,
-    pub pitch: ByteAngle,
+    pub yaw: f32,
+    pub pitch: f32,
     pub flags: TeleportRelativeFlags,
     pub on_ground: bool,
 }

--- a/crates/valence_protocol/src/packets/play/transfer_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/transfer_s2c.rs
@@ -1,11 +1,8 @@
-use std::borrow::Cow;
-
-use valence_binary::{Decode, Encode, VarInt};
-use valence_ident::Ident;
+use valence_binary::{Bounded, Decode, Encode, VarInt};
 
 use crate::Packet;
 #[derive(Clone, Debug, Encode, Decode, Packet)]
 pub struct TransferS2c<'a> {
-    pub host: Ident<Cow<'a, str>>,
+    pub host: Bounded<&'a str, 32767>,
     pub port: VarInt,
 }

--- a/crates/valence_protocol/src/packets/play/update_mob_effect_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/update_mob_effect_s2c.rs
@@ -6,7 +6,7 @@ use crate::Packet;
 pub struct UpdateMobEffectS2c {
     pub entity_id: VarInt,
     pub effect_id: VarInt, // TODO: effect ID registry.
-    pub amplifier: u8,
+    pub amplifier: VarInt,
     pub duration: VarInt,
     pub flags: Flags,
 }

--- a/crates/valence_protocol/src/packets/play/update_mob_effect_s2c.rs
+++ b/crates/valence_protocol/src/packets/play/update_mob_effect_s2c.rs
@@ -17,6 +17,7 @@ pub struct Flags {
     pub is_ambient: bool,
     pub show_particles: bool,
     pub show_icon: bool,
-    #[bits(5)]
+    pub blend: bool,
+    #[bits(4)]
     _pad: u8,
 }

--- a/crates/valence_server/src/keepalive.rs
+++ b/crates/valence_server/src/keepalive.rs
@@ -37,7 +37,7 @@ impl Default for KeepaliveSettings {
 #[derive(Component, Debug)]
 pub struct KeepaliveState {
     got_keepalive: bool,
-    last_keepalive_id: u64,
+    last_keepalive_id: i64,
     last_send: Instant,
 }
 

--- a/crates/valence_server/src/status_effect.rs
+++ b/crates/valence_server/src/status_effect.rs
@@ -60,7 +60,7 @@ fn create_packet(effect: &ActiveStatusEffect) -> UpdateMobEffectS2c {
     UpdateMobEffectS2c {
         entity_id: VarInt(0), // We reserve ID 0 for clients.
         effect_id: VarInt(i32::from(effect.status_effect().to_raw())),
-        amplifier: effect.amplifier(),
+        amplifier: VarInt(effect.amplifier()),
         duration: VarInt(effect.remaining_duration().unwrap_or(-1)),
         flags: update_mob_effect_s2c::Flags::new()
             .with_is_ambient(effect.ambient())
@@ -143,41 +143,41 @@ fn set_swirl(
 
 /// Used to set the color of the swirls in the potion effect.
 ///
-/// Equivalent to net.minecraft.potion.PotionUtil#getColor
+/// Equivalent to net.minecraft.component.type.PotionContentsComponent#mixColors (Yarn mapping).
 fn _get_color(effects: &ActiveStatusEffects) -> i32 {
     if effects.no_effects() {
-        // vanilla mc seems to return 0x385dc6 if there are no effects
+        // vanilla mc seems to return 0xFF385DC6 (i32), decimal: -13083194 if there are no effects
         // dunno why
         // imma just say to return 0 to remove the swirls
         return 0;
     }
 
     let effects = effects.get_current_effects();
-    let mut f = 0.0;
-    let mut g = 0.0;
-    let mut h = 0.0;
-    let mut j = 0.0;
+    let mut r = 0;
+    let mut g = 0;
+    let mut b = 0;
+    let mut total = 0;
 
     for status_effect_instance in effects {
         if !status_effect_instance.show_particles() {
             continue;
         }
 
-        let k = status_effect_instance.status_effect().color();
-        let l = f32::from(status_effect_instance.amplifier() + 1);
-        f += (l * ((k >> 16) & 0xff) as f32) / 255.0;
-        g += (l * ((k >> 8) & 0xff) as f32) / 255.0;
-        h += (l * ((k) & 0xff) as f32) / 255.0;
-        j += l;
+        let color: u32 = status_effect_instance.status_effect().color();
+        let weight = (status_effect_instance.amplifier() + 1) as u32;
+        r += weight * ((color >> 16) & 0xff);
+        g += weight * ((color >> 8) & 0xff);
+        b += weight * ((color) & 0xff);
+        total += weight;
     }
 
-    if j == 0.0 {
+    if total == 0 {
         return 0;
     }
 
-    f = f / j * 255.0;
-    g = g / j * 255.0;
-    h = h / j * 255.0;
-
-    ((f as i32) << 16) | ((g as i32) << 8) | (h as i32)
+    let r = r / total;
+    let g = g / total;
+    let b = b / total;
+    // Alpha is always 255
+    ((0xFF_u32 << 24) | (r << 16) | (g << 8) | b) as i32
 }

--- a/examples/command.rs
+++ b/examples/command.rs
@@ -5,7 +5,9 @@ use std::ops::DerefMut;
 use command::graph::CommandGraphBuilder;
 use command::handler::CommandResultEvent;
 use command::parsers::entity_selector::{EntitySelector, EntitySelectors};
-use command::parsers::{CommandArg, GreedyString, QuotableString};
+use command::parsers::{
+    CommandArg, CommandArgParseError, GreedyString, ParseInput, QuotableString,
+};
 use command::scopes::CommandScopes;
 use command::{parsers, AddCommand, Command, CommandScopeRegistry, ModifierValue};
 use command_macros::Command;
@@ -13,6 +15,7 @@ use parsers::{Vec2 as Vec2Parser, Vec3 as Vec3Parser};
 use rand::prelude::IteratorRandom;
 use valence::entity::living::LivingEntity;
 use valence::prelude::*;
+use valence::protocol::packets::play::commands_s2c::Parser;
 use valence::*;
 use valence_server::op_level::OpLevel;
 
@@ -59,6 +62,26 @@ enum GamemodeCommand {
 pub(crate) struct StructCommand {
     gamemode: GameMode,
     target: Option<EntitySelector>,
+}
+
+#[derive(Command, Debug, Clone)]
+#[paths("say {message}")]
+#[scopes("valence.command.say")]
+pub(crate) struct SayCommand {
+    message: SignedMessage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct SignedMessage(String);
+
+impl CommandArg for SignedMessage {
+    fn parse_arg(input: &mut ParseInput) -> Result<Self, CommandArgParseError> {
+        GreedyString::parse_arg(input).map(|message| Self(message.0))
+    }
+
+    fn display() -> Parser<'static> {
+        Parser::Message
+    }
 }
 
 #[derive(Command, Debug, Clone)]
@@ -172,12 +195,20 @@ impl Command for ComplexRedirectionCommand {
 
 pub fn main() {
     App::new()
+        .insert_resource(NetworkSettings {
+            // This is required for the signed command example (/say)
+            connection_mode: ConnectionMode::Online {
+                prevent_proxy_connections: false,
+            },
+            ..Default::default()
+        })
         .add_plugins(DefaultPlugins)
         .add_command::<TestCommand>()
         .add_command::<TeleportCommand>()
         .add_command::<GamemodeCommand>()
         .add_command::<ComplexRedirectionCommand>()
         .add_command::<StructCommand>()
+        .add_command::<SayCommand>()
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -190,6 +221,7 @@ pub fn main() {
                 handle_complex_command,
                 handle_gamemode_command,
                 handle_struct_command,
+                handle_say_command,
             ),
         )
         .run();
@@ -447,6 +479,16 @@ fn handle_struct_command(
             "Struct command executed with data:\n {:#?}",
             &event.result
         ));
+    }
+}
+
+fn handle_say_command(
+    mut events: EventReader<CommandResultEvent<SayCommand>>,
+    mut clients: Query<&mut Client>,
+) {
+    for event in events.read() {
+        let client = &mut clients.get_mut(event.executor).unwrap();
+        client.send_chat_message(format!("Signed /say received: {}", event.result.message.0));
     }
 }
 

--- a/examples/command.rs
+++ b/examples/command.rs
@@ -5,9 +5,7 @@ use std::ops::DerefMut;
 use command::graph::CommandGraphBuilder;
 use command::handler::CommandResultEvent;
 use command::parsers::entity_selector::{EntitySelector, EntitySelectors};
-use command::parsers::{
-    CommandArg, CommandArgParseError, GreedyString, ParseInput, QuotableString,
-};
+use command::parsers::{CommandArg, GreedyString, QuotableString};
 use command::scopes::CommandScopes;
 use command::{parsers, AddCommand, Command, CommandScopeRegistry, ModifierValue};
 use command_macros::Command;
@@ -15,7 +13,6 @@ use parsers::{Vec2 as Vec2Parser, Vec3 as Vec3Parser};
 use rand::prelude::IteratorRandom;
 use valence::entity::living::LivingEntity;
 use valence::prelude::*;
-use valence::protocol::packets::play::commands_s2c::Parser;
 use valence::*;
 use valence_server::op_level::OpLevel;
 
@@ -62,26 +59,6 @@ enum GamemodeCommand {
 pub(crate) struct StructCommand {
     gamemode: GameMode,
     target: Option<EntitySelector>,
-}
-
-#[derive(Command, Debug, Clone)]
-#[paths("say {message}")]
-#[scopes("valence.command.say")]
-pub(crate) struct SayCommand {
-    message: SignedMessage,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-struct SignedMessage(String);
-
-impl CommandArg for SignedMessage {
-    fn parse_arg(input: &mut ParseInput) -> Result<Self, CommandArgParseError> {
-        GreedyString::parse_arg(input).map(|message| Self(message.0))
-    }
-
-    fn display() -> Parser<'static> {
-        Parser::Message
-    }
 }
 
 #[derive(Command, Debug, Clone)]
@@ -195,20 +172,12 @@ impl Command for ComplexRedirectionCommand {
 
 pub fn main() {
     App::new()
-        .insert_resource(NetworkSettings {
-            // This is required for the signed command example (/say)
-            connection_mode: ConnectionMode::Online {
-                prevent_proxy_connections: false,
-            },
-            ..Default::default()
-        })
         .add_plugins(DefaultPlugins)
         .add_command::<TestCommand>()
         .add_command::<TeleportCommand>()
         .add_command::<GamemodeCommand>()
         .add_command::<ComplexRedirectionCommand>()
         .add_command::<StructCommand>()
-        .add_command::<SayCommand>()
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -221,7 +190,6 @@ pub fn main() {
                 handle_complex_command,
                 handle_gamemode_command,
                 handle_struct_command,
-                handle_say_command,
             ),
         )
         .run();
@@ -479,16 +447,6 @@ fn handle_struct_command(
             "Struct command executed with data:\n {:#?}",
             &event.result
         ));
-    }
-}
-
-fn handle_say_command(
-    mut events: EventReader<CommandResultEvent<SayCommand>>,
-    mut clients: Query<&mut Client>,
-) {
-    for event in events.read() {
-        let client = &mut clients.get_mut(event.executor).unwrap();
-        client.send_chat_message(format!("Signed /say received: {}", event.result.message.0));
     }
 }
 

--- a/examples/potions.rs
+++ b/examples/potions.rs
@@ -151,14 +151,14 @@ pub fn add_potion_effect(
     }
 }
 
-fn adjust_modifier_amount(amplifier: u8, amount: f64) -> f64 {
+fn adjust_modifier_amount(amplifier: i32, amount: f64) -> f64 {
     amount * f64::from(amplifier + 1)
 }
 
 fn apply_potion_attribute(
     attributes: &mut Mut<EntityAttributes>,
     health: &mut Option<Mut<Health>>,
-    amplifier: u8,
+    amplifier: i32,
     attr: AttributeModifier,
     name: &str,
 ) {
@@ -222,7 +222,7 @@ pub fn handle_status_effect_added(
                     // need to keep track of the previous absorption value and subtract that from
                     // the new value (because you can take damage while having absorption)
                     if let Some(mut absorption) = absorption {
-                        absorption.0 += f32::from(effect.amplifier() + 1) * 4.0;
+                        absorption.0 += (effect.amplifier() + 1) as f32 * 4.0;
                     }
                 }
                 StatusEffect::InstantHealth => {
@@ -274,7 +274,7 @@ pub fn handle_status_effect_removed(
             match effect.status_effect() {
                 StatusEffect::Absorption => {
                     if let Some(mut absorption) = absorption {
-                        absorption.0 -= f32::from(effect.amplifier() + 1) * 4.0;
+                        absorption.0 -= (effect.amplifier() + 1) as f32 * 4.0;
                     }
                 }
                 StatusEffect::Glowing => {
@@ -305,7 +305,7 @@ pub fn handle_status_effect_update(
         for effect in status.get_current_effects() {
             match effect.status_effect() {
                 StatusEffect::Regeneration => {
-                    let i = 50 >> u32::from(effect.amplifier().min(31));
+                    let i = 50 >> effect.amplifier().min(31);
 
                     if i == 0 || effect.active_ticks() % i == 0 {
                         if let Some(ref mut health) = health {
@@ -318,7 +318,7 @@ pub fn handle_status_effect_update(
                     }
                 }
                 StatusEffect::Poison => {
-                    let i = 25 >> u32::from(effect.amplifier().min(31));
+                    let i = 25 >> effect.amplifier().min(31);
 
                     if i == 0 || effect.active_ticks() % i == 0 {
                         if let Some(ref mut health) = health {
@@ -327,7 +327,7 @@ pub fn handle_status_effect_update(
                     }
                 }
                 StatusEffect::Wither => {
-                    let i = 40 >> u32::from(effect.amplifier().min(31));
+                    let i = 40 >> effect.amplifier().min(31);
 
                     if i == 0 || effect.active_ticks() % i == 0 {
                         if let Some(ref mut health) = health {

--- a/src/tests/potions.rs
+++ b/src/tests/potions.rs
@@ -44,7 +44,7 @@ fn test_status_effects_packets() {
         packet.effect_id,
         i32::from(StatusEffect::BadOmen.to_raw()).into()
     ); // Bad Omen
-    assert_eq!(packet.amplifier, 1);
+    assert_eq!(packet.amplifier, VarInt(1));
     assert_eq!(packet.duration, VarInt(100));
 
     // Clear the potion effect


### PR DESCRIPTION
# Objective

- Fix remaining misalignment on the packet definitions for `1.21.5` based on the protocol wiki page.

# Solution

Every commit fixes 1 type of packet mismatch that was found, the commit messages are descriptive for what was fixed or changed

Original PR with review comments: https://github.com/JackCrumpLeys/valence/pull/29

