### PR TITLE
Fix velocity packet decoding and encoding

### DIFF
--- a/crates/chunkedge_binary/src/var_int.rs
+++ b/crates/chunkedge_binary/src/var_int.rs
@@ -40,7 +40,7 @@ impl VarInt {
     ///
     /// This is the size of "canonical" (non-padded) encoding for this
     /// value, not necessarily the number of bytes that were consumed
-    /// while decoding it. Minecraft VarInts may be padded by using
+    /// while decoding it. Minecraft `VarInts` may be padded by using
     /// more continuation bytes than the value requires, so callers that
     /// need the decoded wire length should compare the input slice length
     /// before and after decoding instead.

--- a/crates/chunkedge_binary/src/var_int.rs
+++ b/crates/chunkedge_binary/src/var_int.rs
@@ -37,6 +37,13 @@ impl VarInt {
 
     /// Returns the exact number of bytes this varint will write when
     /// [`Encode::encode`] is called, assuming no error occurs.
+    ///
+    /// This is the size of "canonical" (non-padded) encoding for this
+    /// value, not necessarily the number of bytes that were consumed
+    /// while decoding it. Minecraft VarInts may be padded by using
+    /// more continuation bytes than the value requires, so callers that
+    /// need the decoded wire length should compare the input slice length
+    /// before and after decoding instead.
     pub const fn written_size(self) -> usize {
         match self.0 {
             0 => 1,

--- a/crates/chunkedge_binary/src/var_long.rs
+++ b/crates/chunkedge_binary/src/var_long.rs
@@ -37,7 +37,7 @@ impl VarLong {
     ///
     /// This is the size of "canonical" (non-padded) encoding for this
     /// value, not necessarily the number of bytes that were consumed
-    /// while decoding it. Minecraft VarLongs may be padded by using
+    /// while decoding it. Minecraft `VarLongs` may be padded by using
     /// more continuation bytes than the value requires, so callers that
     /// need the decoded wire length should compare the input slice length
     /// before and after decoding instead.

--- a/crates/chunkedge_binary/src/var_long.rs
+++ b/crates/chunkedge_binary/src/var_long.rs
@@ -34,6 +34,13 @@ impl VarLong {
 
     /// Returns the exact number of bytes this varlong will write when
     /// [`Encode::encode`] is called, assuming no error occurs.
+    ///
+    /// This is the size of "canonical" (non-padded) encoding for this
+    /// value, not necessarily the number of bytes that were consumed
+    /// while decoding it. Minecraft VarLongs may be padded by using
+    /// more continuation bytes than the value requires, so callers that
+    /// need the decoded wire length should compare the input slice length
+    /// before and after decoding instead.
     pub fn written_size(self) -> usize {
         match self.0 {
             0 => 1,

--- a/crates/chunkedge_protocol/src/decode.rs
+++ b/crates/chunkedge_protocol/src/decode.rs
@@ -48,7 +48,7 @@ impl PacketDecoder {
             return Ok(None);
         }
 
-        let packet_len_len = VarInt(packet_len).written_size();
+        let packet_len_len = self.buf.len() - r.len();
 
         let mut data;
 
@@ -71,9 +71,9 @@ impl PacketDecoder {
             // Is this packet compressed?
             if data_len > 0 {
                 ensure!(
-                    data_len > self.threshold.0,
-                    "decompressed packet length of {data_len} is <= the compression threshold of \
-                     {}",
+                    data_len >= self.threshold.0,
+                    "decompressed packet length of {data_len} is below the compression threshold \
+                     of {}",
                     self.threshold.0
                 );
 
@@ -91,24 +91,23 @@ impl PacketDecoder {
                     "decompressed packet length is shorter than expected"
                 );
 
-                let total_packet_len = VarInt(packet_len).written_size() + packet_len as usize;
-
-                self.buf.advance(total_packet_len);
+                self.buf.advance(packet_len_len + packet_len as usize);
 
                 data = self.decompress_buf.split();
             } else {
                 debug_assert_eq!(data_len, 0);
 
                 ensure!(
-                    r.len() <= self.threshold.0 as usize,
-                    "uncompressed packet length of {} exceeds compression threshold of {}",
+                    r.len() < self.threshold.0 as usize,
+                    "uncompressed packet length of {} is not below the compression threshold of {}",
                     r.len(),
                     self.threshold.0
                 );
 
+                let data_len_len = packet_len as usize - r.len();
                 let remaining_len = r.len();
 
-                self.buf.advance(packet_len_len + 1);
+                self.buf.advance(packet_len_len + data_len_len);
 
                 data = self.buf.split_to(remaining_len);
             }

--- a/crates/chunkedge_protocol/src/decode.rs
+++ b/crates/chunkedge_protocol/src/decode.rs
@@ -236,3 +236,72 @@ impl PacketFrame {
         Ok(pkt)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_padded_packet_length_and_packet_id() {
+        let mut decoder = PacketDecoder::new();
+
+        // packet_len = 2 encoded in two bytes, then packet_id = 0 encoded in two bytes.
+        decoder.queue_slice(&[0x82, 0x00, 0x80, 0x00]);
+
+        let frame = decoder.try_next_packet().unwrap().unwrap();
+
+        assert_eq!(frame.id, 0);
+        assert!(frame.body.is_empty());
+        assert!(decoder.try_next_packet().unwrap().is_none());
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn accepts_padded_uncompressed_data_length_and_packet_id() {
+        let mut decoder = PacketDecoder::new();
+        decoder.set_compression(CompressionThreshold(256));
+
+        // packet_len = 4 encoded in two bytes, then uncompressed data_len = 0 encoded in two bytes, then packet_id = 0 encoded in two bytes.
+        decoder.queue_slice(&[0x84, 0x00, 0x80, 0x00, 0x80, 0x00]);
+
+        let frame = decoder.try_next_packet().unwrap().unwrap();
+
+        assert_eq!(frame.id, 0);
+        assert!(frame.body.is_empty());
+        assert!(decoder.try_next_packet().unwrap().is_none());
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn accepts_compressed_packet_at_compression_threshold() {
+        use std::io::Read;
+
+        use chunkedge_binary::Encode;
+        use flate2::bufread::ZlibEncoder;
+        use flate2::Compression;
+
+        let threshold = 3;
+        let mut decoder = PacketDecoder::new();
+        decoder.set_compression(CompressionThreshold(threshold));
+
+        let uncompressed_packet = [0x00, 0xab, 0xcd];
+        let mut compressed_packet = vec![];
+        ZlibEncoder::new(&uncompressed_packet[..], Compression::new(4))
+            .read_to_end(&mut compressed_packet)
+            .unwrap();
+
+        let packet_len = VarInt(threshold).written_size() + compressed_packet.len();
+        let mut packet = vec![];
+        VarInt(packet_len as i32).encode(&mut packet).unwrap();
+        VarInt(threshold).encode(&mut packet).unwrap();
+        packet.extend_from_slice(&compressed_packet);
+
+        decoder.queue_slice(&packet);
+
+        let frame = decoder.try_next_packet().unwrap().unwrap();
+
+        assert_eq!(frame.id, 0);
+        assert_eq!(&frame.body[..], [0xab, 0xcd]);
+        assert!(decoder.try_next_packet().unwrap().is_none());
+    }
+}

--- a/crates/chunkedge_protocol/src/encode.rs
+++ b/crates/chunkedge_protocol/src/encode.rs
@@ -74,7 +74,7 @@ impl PacketEncoder {
             use flate2::bufread::ZlibEncoder;
             use flate2::Compression;
 
-            if data_len > self.threshold.0 as usize {
+            if data_len >= self.threshold.0 as usize {
                 let mut z = ZlibEncoder::new(&self.buf[start_len..], Compression::new(4));
 
                 self.compress_buf.clear();
@@ -341,7 +341,7 @@ where
 
     let data_len = buf.len() - start_len;
 
-    if data_len > threshold as usize {
+    if data_len >= threshold as usize {
         let mut z = ZlibEncoder::new(&buf[start_len..], Compression::new(4));
 
         let mut scratch = vec![];

--- a/tools/packet_inspector/src/packet_io.rs
+++ b/tools/packet_inspector/src/packet_io.rs
@@ -72,7 +72,7 @@ impl PacketIoWriter {
         let uncompressed_packet_length_varint = VarInt(uncompressed_packet_length as i32);
 
         if threshold.0 >= 0 {
-            if uncompressed_packet_length > threshold.0 as usize {
+            if uncompressed_packet_length >= threshold.0 as usize {
                 use std::io::Read;
 
                 use flate2::bufread::ZlibEncoder;


### PR DESCRIPTION
# Objective

- Fix velocity support

# Solution

- Use actual varint size instead of using our encoding strategy to make up a size.
- Compress when >= compression threshold instead of >
