### PR TITLE
respect components for merging/swapping.

### DIFF
--- a/crates/chunkedge_inventory/Cargo.toml
+++ b/crates/chunkedge_inventory/Cargo.toml
@@ -20,3 +20,4 @@ derive_more = { workspace = true, features = [
 ] }
 tracing.workspace = true
 chunkedge_server.workspace = true
+chunkedge_item.workspace = true

--- a/crates/chunkedge_inventory/src/validate.rs
+++ b/crates/chunkedge_inventory/src/validate.rs
@@ -1221,4 +1221,58 @@ mod tests {
             "cursor should hold Probe B after the swap, got {new_cursor:?}",
         );
     }
+
+    #[test]
+    fn click_no_merge_same_kind_different_components() {
+        // If two ItemStacks are of the same ItemKind but have different components, they should be treated as different items.
+        // If it doesn't, and both items can stack (based on their ItemKind) then clicking one while holding the other will
+        // result in merging the stacks on the server, while they are actually differnet items and should not merge.
+        //This previously happened resutling in this regression test getting added when the bug was fixed.
+        use chunkedge_item::ItemComponent;
+
+        let mut player_inventory = Inventory::new(InventoryKind::Player);
+
+        let probe_a = ItemStack::new(ItemKind::Diamond, 4)
+            .with_components(vec![ItemComponent::DyedColor { color: 0xff0000 }]);
+        let probe_b = ItemStack::new(ItemKind::Diamond, 5)
+            .with_components(vec![ItemComponent::DyedColor { color: 0x0000ff }]);
+
+        // slot 36 = Probe B, cursor = Probe A.
+        player_inventory.set_slot(36, probe_b.clone());
+        let cursor_item = CursorItem(probe_a.clone());
+
+        // Client clicks slot 36. client perspective: the slot now holds Probe A
+        // (what was on the cursor) and the cursor now holds Probe B.
+        let packet = ContainerClickC2s {
+            window_id: VarInt(0),
+            state_id: VarInt(0),
+            slot_idx: 36,
+            button: 0,
+            mode: ClickMode::Click,
+            slot_changes: vec![SlotChange {
+                idx: 36,
+                stack: probe_a.clone(),
+            }
+            .into()]
+            .into(),
+            carried_item: probe_b.clone().into(),
+        };
+
+        let (new_cursor, slot_changes) =
+            validate_click_slot_packet(&packet, &player_inventory, None, &cursor_item)
+                .expect("packet should validate");
+
+        assert_eq!(slot_changes.len(), 1);
+        assert_eq!(slot_changes[0].idx, 36);
+
+        assert_eq!(
+            slot_changes[0].stack, probe_a,
+            "slot 36 should hold Probe A after the swap, got {:?}",
+            slot_changes[0].stack,
+        );
+        assert_eq!(
+            new_cursor, probe_b,
+            "cursor should hold Probe B after the swap, got {new_cursor:?}",
+        );
+    }
 }

--- a/crates/chunkedge_inventory/src/validate.rs
+++ b/crates/chunkedge_inventory/src/validate.rs
@@ -216,7 +216,7 @@ pub(super) fn validate_click_slot_packet(
                         && match (!old_slot.is_empty(), !cursor_item.is_empty()) {
                             // We assume we only want to consider items for merging if they have the same
                             // kind and components.
-                            // 
+                            //
                             // TODO: as noted in a previous component, the client might add additional NBT data. confirm if this is the case and allow merging if client item has additional components.
                             (true, true) => !old_slot.is_same_item_same_components(&cursor_item.0),
                             (true, false) => true,
@@ -1168,10 +1168,9 @@ mod tests {
             .expect("packet should be valid");
     }
 
-
     #[test]
     fn click_swap_same_kind_different_components() {
-        // Repro of bug from https://github.com/jobpaardekooper/valence/commit/d86a64f69a2ce66e2141e6412d537d9ee2cee97c: 
+        // Repro of bug from https://github.com/jobpaardekooper/valence/commit/d86a64f69a2ce66e2141e6412d537d9ee2cee97c:
         // examples/item_components.rs:
         // serverside, two items (with same kind+count) with different components must be treated
         // as different items, so left-clicking one while holding the other is a
@@ -1220,8 +1219,7 @@ mod tests {
         );
         assert_eq!(
             new_cursor, probe_b,
-            "cursor should hold Probe B after the swap, got {:?}",
-            new_cursor,
+            "cursor should hold Probe B after the swap, got {new_cursor:?}",
         );
     }
 }

--- a/crates/chunkedge_inventory/src/validate.rs
+++ b/crates/chunkedge_inventory/src/validate.rs
@@ -80,12 +80,10 @@ pub(super) fn validate_click_slot_packet(
         }
         ClickMode::ShiftClick => {
             ensure!((0..=1).contains(&packet.button), "invalid button");
-            // Shift click does not interact with the cursor at all.
-            // cursor should not change.
             ensure!(
                 packet.carried_item.item == cursor_item.0.item
                     && packet.carried_item.count == cursor_item.0.count,
-                "shift click must not change the cursor"
+                "shift clicking must not change the cursor but it did"
             );
             ensure!(
                 (0..=max_slot).contains(&(packet.slot_idx as u16)),
@@ -216,9 +214,11 @@ pub(super) fn validate_click_slot_packet(
                         && match (!old_slot.is_empty(), !cursor_item.is_empty()) {
                             // We assume we only want to consider items for merging if they have the same
                             // kind and components.
-                            //
-                            // TODO: as noted in a previous component, the client might add additional NBT data. confirm if this is the case and allow merging if client item has additional components.
-                            (true, true) => !old_slot.is_same_item_same_components(&cursor_item.0),
+
+                            // TODO: The client might add additional NBT data. confirm if this is the case and allow merging if client item has additional components.
+                            (true, true) => {
+                                !old_slot.is_same_item_kind_and_same_components(&cursor_item.0)
+                            }
                             (true, false) => true,
                             (false, true) => cursor_item.count <= cursor_item.item.max_stack(),
                             (false, false) => false,
@@ -244,8 +244,9 @@ pub(super) fn validate_click_slot_packet(
                     } else {
                         // assert that a merge occurs
                         if !cursor_item.is_empty() && !old_slot.is_empty() {
+                            // We assume that itemkind + itemcomponents -> stackable.
                             ensure!(
-                                old_slot.is_same_item_same_components(&cursor_item.0), // We assume that itemkind + itemcomponents -> stackable.
+                                old_slot.is_same_item_kind_and_same_components(&cursor_item.0),
                                 "merge requires stackable cursor and slot"
                             );
                         }
@@ -1170,11 +1171,9 @@ mod tests {
 
     #[test]
     fn click_swap_same_kind_different_components() {
-        // Repro of bug from https://github.com/jobpaardekooper/valence/commit/d86a64f69a2ce66e2141e6412d537d9ee2cee97c:
-        // examples/item_components.rs:
-        // serverside, two items (with same kind+count) with different components must be treated
-        // as different items, so left-clicking one while holding the other is a
-        // SWAP — not a merge that loses Probe B.
+        // If two ItemStacks are of the same ItemKind but have different components, they should be treated as different items.
+        // If it doesn't, then clicking one while holding the other will result in an item sawp on the client, but not on the server.
+        // This results in an inventory desync. This previously happened resutling in this regression test getting added when the bug was fixed.
         use chunkedge_item::ItemComponent;
 
         let mut player_inventory = Inventory::new(InventoryKind::Player);

--- a/crates/chunkedge_inventory/src/validate.rs
+++ b/crates/chunkedge_inventory/src/validate.rs
@@ -1226,7 +1226,7 @@ mod tests {
     fn click_no_merge_same_kind_different_components() {
         // If two ItemStacks are of the same ItemKind but have different components, they should be treated as different items.
         // If it doesn't, and both items can stack (based on their ItemKind) then clicking one while holding the other will
-        // result in merging the stacks on the server, while they are actually differnet items and should not merge.
+        // result in merging the stacks on the server, while they are actually different items and should not merge.
         //This previously happened resutling in this regression test getting added when the bug was fixed.
         use chunkedge_item::ItemComponent;
 

--- a/crates/chunkedge_inventory/src/validate.rs
+++ b/crates/chunkedge_inventory/src/validate.rs
@@ -80,9 +80,12 @@ pub(super) fn validate_click_slot_packet(
         }
         ClickMode::ShiftClick => {
             ensure!((0..=1).contains(&packet.button), "invalid button");
+            // Shift click does not interact with the cursor at all.
+            // cursor should not change.
             ensure!(
-                packet.carried_item.is_empty(),
-                "carried item must be empty for a hotbar swap"
+                packet.carried_item.item == cursor_item.0.item
+                    && packet.carried_item.count == cursor_item.0.count,
+                "shift click must not change the cursor"
             );
             ensure!(
                 (0..=max_slot).contains(&(packet.slot_idx as u16)),
@@ -94,6 +97,10 @@ pub(super) fn validate_click_slot_packet(
             ensure!(
                 packet.carried_item.is_empty(),
                 "carried item must be empty for a hotbar swap"
+            );
+            ensure!(
+                cursor_item.is_empty(),
+                "cursor must be empty for a hotbar swap"
             );
         }
         ClickMode::CreativeMiddleClick => {
@@ -204,12 +211,14 @@ pub(super) fn validate_click_slot_packet(
 
                     let hashed_change = &packet.slot_changes[0];
                     let old_slot = window.slot(hashed_change.idx as u16);
-                    // TODO: make sure NBT is the same.
-                    //       Sometimes, the client will add nbt data to an item if it's missing,
-                    // like       "Damage" to a sword.
+
                     let should_swap: bool = packet.button == 0
                         && match (!old_slot.is_empty(), !cursor_item.is_empty()) {
-                            (true, true) => old_slot.item != cursor_item.item,
+                            // We assume we only want to consider items for merging if they have the same
+                            // kind and components.
+                            // 
+                            // TODO: as noted in a previous component, the client might add additional NBT data. confirm if this is the case and allow merging if client item has additional components.
+                            (true, true) => !old_slot.is_same_item_same_components(&cursor_item.0),
                             (true, false) => true,
                             (false, true) => cursor_item.count <= cursor_item.item.max_stack(),
                             (false, false) => false,
@@ -227,7 +236,6 @@ pub(super) fn validate_click_slot_packet(
                             "swapped items must match"
                         );
 
-                        // Find the unhashed cursor
                         new_slot_changes.push(SlotChange {
                             idx: hashed_change.idx,
                             stack: cursor_item.0.clone().with_count(hashed_change.stack.count),
@@ -235,6 +243,13 @@ pub(super) fn validate_click_slot_packet(
                         new_cursor_stack = old_slot.clone().with_count(packet.carried_item.count);
                     } else {
                         // assert that a merge occurs
+                        if !cursor_item.is_empty() && !old_slot.is_empty() {
+                            ensure!(
+                                old_slot.is_same_item_same_components(&cursor_item.0), // We assume that itemkind + itemcomponents -> stackable.
+                                "merge requires stackable cursor and slot"
+                            );
+                        }
+
                         let count_deltas = calculate_net_item_delta(packet, &window, cursor_item);
                         ensure!(
                             count_deltas == 0,
@@ -1151,5 +1166,62 @@ mod tests {
 
         validate_click_slot_packet(&packet, &player_inventory, None, &cursor_item)
             .expect("packet should be valid");
+    }
+
+
+    #[test]
+    fn click_swap_same_kind_different_components() {
+        // Repro of bug from https://github.com/jobpaardekooper/valence/commit/d86a64f69a2ce66e2141e6412d537d9ee2cee97c: 
+        // examples/item_components.rs:
+        // serverside, two items (with same kind+count) with different components must be treated
+        // as different items, so left-clicking one while holding the other is a
+        // SWAP — not a merge that loses Probe B.
+        use chunkedge_item::ItemComponent;
+
+        let mut player_inventory = Inventory::new(InventoryKind::Player);
+
+        let probe_a = ItemStack::new(ItemKind::IronSword, 1)
+            .with_components(vec![ItemComponent::DyedColor { color: 0xff0000 }]);
+        let probe_b = ItemStack::new(ItemKind::IronSword, 1)
+            .with_components(vec![ItemComponent::DyedColor { color: 0x0000ff }]);
+
+        // slot 36 = Probe B, cursor = Probe A.
+        player_inventory.set_slot(36, probe_b.clone());
+        let cursor_item = CursorItem(probe_a.clone());
+
+        // Client clicks slot 36. client perspective: the slot now holds Probe A
+        // (what was on the cursor) and the cursor now holds Probe B.
+        let packet = ContainerClickC2s {
+            window_id: VarInt(0),
+            state_id: VarInt(0),
+            slot_idx: 36,
+            button: 0,
+            mode: ClickMode::Click,
+            slot_changes: vec![SlotChange {
+                idx: 36,
+                stack: probe_a.clone(),
+            }
+            .into()]
+            .into(),
+            carried_item: probe_b.clone().into(),
+        };
+
+        let (new_cursor, slot_changes) =
+            validate_click_slot_packet(&packet, &player_inventory, None, &cursor_item)
+                .expect("packet should validate");
+
+        assert_eq!(slot_changes.len(), 1);
+        assert_eq!(slot_changes[0].idx, 36);
+
+        assert_eq!(
+            slot_changes[0].stack, probe_a,
+            "slot 36 should hold Probe A after the swap, got {:?}",
+            slot_changes[0].stack,
+        );
+        assert_eq!(
+            new_cursor, probe_b,
+            "cursor should hold Probe B after the swap, got {:?}",
+            new_cursor,
+        );
     }
 }

--- a/crates/chunkedge_item/src/stack.rs
+++ b/crates/chunkedge_item/src/stack.rs
@@ -197,6 +197,12 @@ impl ItemStack {
         matches!(self.item, ItemKind::Air) || self.count <= 0
     }
 
+    /// Returns `true` if `self` and `other` are the same item kind with the
+    /// same component data. Counts are ignored.
+    pub fn is_same_item_same_components(&self, other: &Self) -> bool {
+        self.item == other.item && self.components == other.components
+    }
+
     pub fn encode_recursive<W: Write>(
         &self,
         mut w: W,

--- a/crates/chunkedge_item/src/stack.rs
+++ b/crates/chunkedge_item/src/stack.rs
@@ -198,8 +198,8 @@ impl ItemStack {
     }
 
     /// Returns `true` if `self` and `other` are the same item kind with the
-    /// same component data. Counts are ignored.
-    pub fn is_same_item_same_components(&self, other: &Self) -> bool {
+    /// same component data. **Counts are ignored.**
+    pub fn is_same_item_kind_and_same_components(&self, other: &Self) -> bool {
         self.item == other.item && self.components == other.components
     }
 


### PR DESCRIPTION
Previously the logic for validating ContainerClick packet logic did not respect item components for deciding to swap or merge items.

This PR fixes this by considering items "stackable" if they have same type + same components.