### PR TITLE
Implement passengers API

### DIFF
--- a/crates/chunkedge_server/src/lib.rs
+++ b/crates/chunkedge_server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod layer;
 pub mod message;
 pub mod movement;
 pub mod op_level;
+pub mod passenger;
 pub mod resource_pack;
 pub mod spawn;
 pub mod status;

--- a/crates/chunkedge_server/src/passenger.rs
+++ b/crates/chunkedge_server/src/passenger.rs
@@ -1,0 +1,157 @@
+//! Passenger/riding API built on Bevy's entity relationships.
+//!
+//! Insert [`Riding`] on a passenger entity to mount it onto a vehicle; the
+//! vehicle's [`Passengers`] component and the clients viewing it are kept in
+//! sync automatically.
+
+use std::borrow::Cow;
+
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_ecs::relationship::RelationshipTarget;
+use chunkedge_entity::{EntityId, EntityLayerId, Position};
+use derive_more::Deref;
+
+use crate::client::{
+    Client, FlushPacketsSet, LoadEntityForClientEvent, ViewDistance, VisibleEntityLayers,
+};
+use crate::layer::UpdateLayersPreClientSet;
+use crate::protocol::packets::play::SetPassengersS2c;
+use crate::protocol::{VarInt, WritePacket};
+use crate::{ChunkView, EntityLayer, Layer};
+
+pub struct PassengerPlugin;
+
+impl Plugin for PassengerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (send_passengers, send_empty_passengers_on_removal).before(UpdateLayersPreClientSet),
+        )
+        .add_systems(
+            PostUpdate,
+            send_passengers_on_entity_load.before(FlushPacketsSet),
+        );
+    }
+}
+
+/// Placed on a passenger entity, pointing at the vehicle it rides.
+///
+/// Inserting this component mounts the entity; removing it (or despawning the
+/// entity) dismounts it. The vehicle's [`Passengers`] component is kept in sync
+/// automatically.
+#[derive(Component, Copy, Clone, PartialEq, Eq, Debug, Deref)]
+#[relationship(relationship_target = Passengers)]
+pub struct Riding(pub Entity);
+
+/// Automatically maintained on a vehicle entity; lists the entities currently
+/// riding it.
+///
+/// Do not construct or mutate this directly. It is populated by inserting
+/// [`Riding`] on passenger entities.
+#[derive(Component, Debug)]
+#[relationship_target(relationship = Riding)]
+pub struct Passengers(Vec<Entity>);
+
+fn send_passengers(
+    vehicles: Query<(&EntityId, &Passengers, &EntityLayerId, &Position), Changed<Passengers>>,
+    entity_ids: Query<&EntityId>,
+    mut clients: Query<(
+        &mut Client,
+        &EntityId,
+        &Position,
+        &ViewDistance,
+        &VisibleEntityLayers,
+    )>,
+) {
+    for (vehicle_id, passengers, layer_id, vehicle_pos) in &vehicles {
+        for (mut client, client_id, client_pos, view_distance, visible_layers) in &mut clients {
+            if !visible_layers.0.contains(&layer_id.0) {
+                continue;
+            }
+
+            let view = ChunkView::new(client_pos.0.into(), view_distance.get());
+            if !view.contains(vehicle_pos.0.into()) {
+                continue;
+            }
+
+            client.write_packet(&packet_for_viewer(
+                client_id.get(),
+                vehicle_id.get(),
+                passengers,
+                &entity_ids,
+            ));
+        }
+    }
+}
+
+fn send_empty_passengers_on_removal(
+    mut removed: RemovedComponents<Passengers>,
+    vehicles: Query<(&EntityId, &EntityLayerId, &Position), Without<Passengers>>,
+    mut entity_layers: Query<&mut EntityLayer>,
+) {
+    for entity in removed.read() {
+        let Ok((vehicle_id, layer_id, pos)) = vehicles.get(entity) else {
+            continue;
+        };
+        let Ok(mut entity_layer) = entity_layers.get_mut(layer_id.0) else {
+            continue;
+        };
+
+        let packet = SetPassengersS2c {
+            entity_id: VarInt(vehicle_id.get()),
+            passengers: Cow::Borrowed(&[]),
+        };
+
+        entity_layer.view_writer(pos.0).write_packet(&packet);
+    }
+}
+
+fn send_passengers_on_entity_load(
+    mut events: MessageReader<LoadEntityForClientEvent>,
+    mut clients: Query<(&mut Client, &EntityId)>,
+    vehicles: Query<(&EntityId, &Passengers)>,
+    entity_ids: Query<&EntityId>,
+) {
+    for event in events.read() {
+        let Ok((vehicle_id, passengers)) = vehicles.get(event.entity_loaded) else {
+            continue;
+        };
+        let Ok((mut client, client_id)) = clients.get_mut(event.client) else {
+            continue;
+        };
+
+        client.write_packet(&packet_for_viewer(
+            client_id.get(),
+            vehicle_id.get(),
+            passengers,
+            &entity_ids,
+        ));
+    }
+}
+
+fn packet_for_viewer<'a>(
+    viewer_id: i32,
+    vehicle_id: i32,
+    passengers: &Passengers,
+    entity_ids: &Query<&EntityId>,
+) -> SetPassengersS2c<'a> {
+    let ids: Vec<VarInt> = passengers
+        .iter()
+        .filter_map(|passenger| entity_ids.get(passenger).ok())
+        .map(|id| VarInt(rewrite_self(id.get(), viewer_id)))
+        .collect();
+
+    SetPassengersS2c {
+        entity_id: VarInt(rewrite_self(vehicle_id, viewer_id)),
+        passengers: Cow::Owned(ids),
+    }
+}
+
+fn rewrite_self(id: i32, viewer_id: i32) -> i32 {
+    if id == viewer_id {
+        0
+    } else {
+        id
+    }
+}

--- a/crates/chunkedge_server/src/passenger.rs
+++ b/crates/chunkedge_server/src/passenger.rs
@@ -26,11 +26,11 @@ impl Plugin for PassengerPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             PostUpdate,
-            (send_passengers, send_empty_passengers_on_removal).before(UpdateLayersPreClientSet),
-        )
-        .add_systems(
-            PostUpdate,
-            send_passengers_on_entity_load.before(FlushPacketsSet),
+            (
+                (send_passengers, send_empty_passengers_on_removal)
+                    .before(UpdateLayersPreClientSet),
+                send_passengers_on_entity_load.before(FlushPacketsSet),
+            ),
         );
     }
 }
@@ -47,8 +47,9 @@ pub struct Riding(pub Entity);
 /// Automatically maintained on a vehicle entity; lists the entities currently
 /// riding it.
 ///
-/// Do not construct or mutate this directly. It is populated by inserting
+/// This is populated by inserting
 /// [`Riding`] on passenger entities.
+/// You can access the passenger entities using `.iter()`
 #[derive(Component, Debug)]
 #[relationship_target(relationship = Riding)]
 pub struct Passengers(Vec<Entity>);

--- a/crates/chunkedge_server/src/passenger.rs
+++ b/crates/chunkedge_server/src/passenger.rs
@@ -13,7 +13,7 @@ use chunkedge_entity::{EntityId, EntityLayerId, Position};
 use derive_more::Deref;
 
 use crate::client::{
-    Client, FlushPacketsSet, LoadEntityForClientEvent, ViewDistance, VisibleEntityLayers,
+    Client, FlushPacketsSet, LoadEntityForClientMessage, ViewDistance, VisibleEntityLayers,
 };
 use crate::layer::UpdateLayersPreClientSet;
 use crate::protocol::packets::play::SetPassengersS2c;
@@ -109,16 +109,16 @@ fn send_empty_passengers_on_removal(
 }
 
 fn send_passengers_on_entity_load(
-    mut events: MessageReader<LoadEntityForClientEvent>,
+    mut messages: MessageReader<LoadEntityForClientMessage>,
     mut clients: Query<(&mut Client, &EntityId)>,
     vehicles: Query<(&EntityId, &Passengers)>,
     entity_ids: Query<&EntityId>,
 ) {
-    for event in events.read() {
-        let Ok((vehicle_id, passengers)) = vehicles.get(event.entity_loaded) else {
+    for message in messages.read() {
+        let Ok((vehicle_id, passengers)) = vehicles.get(message.entity_loaded) else {
             continue;
         };
-        let Ok((mut client, client_id)) = clients.get_mut(event.client) else {
+        let Ok((mut client, client_id)) = clients.get_mut(message.client) else {
             continue;
         };
 

--- a/examples/passenger.rs
+++ b/examples/passenger.rs
@@ -1,0 +1,183 @@
+#![allow(clippy::type_complexity)]
+
+use chunkedge::prelude::*;
+
+type VehicleBundle = chunkedge::entity::pig::PigEntityBundle;
+type CowBundle = chunkedge::entity::cow::CowEntityBundle;
+
+const SPAWN_Y: i32 = 64;
+const VEHICLE_POS: [f64; 3] = [0.0, SPAWN_Y as f64 + 1.0, 3.0];
+const COW_POS: [f64; 3] = [2.0, SPAWN_Y as f64 + 1.0, 3.0];
+
+#[derive(Component)]
+struct Vehicle;
+
+#[derive(Component)]
+struct Orbit(DVec3);
+
+const ORBIT_RADIUS: f64 = 2.0;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (
+                init_clients,
+                mount_on_interact,
+                dismount_on_sneak,
+                orbit_entities,
+                despawn_disconnected_clients,
+            ),
+        )
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    server: Res<Server>,
+    dimensions: Res<DimensionTypeRegistry>,
+    biomes: Res<BiomeRegistry>,
+) {
+    let mut layer = LayerBundle::new(ident!("overworld"), &dimensions, &biomes, &server);
+
+    for z in -5..5 {
+        for x in -5..5 {
+            layer.chunk.insert_chunk([x, z], UnloadedChunk::new());
+        }
+    }
+
+    for z in -25..25 {
+        for x in -25..25 {
+            layer
+                .chunk
+                .set_block(BlockPos::new(x, SPAWN_Y, z), BlockState::BEDROCK);
+        }
+    }
+
+    let layer_id = commands.spawn(layer).id();
+
+    commands.spawn((
+        VehicleBundle {
+            layer: EntityLayerId(layer_id),
+            position: Position::new(VEHICLE_POS),
+            ..Default::default()
+        },
+        Vehicle,
+        Orbit(VEHICLE_POS.into()),
+    ));
+
+    let cow = commands
+        .spawn((
+            CowBundle {
+                layer: EntityLayerId(layer_id),
+                position: Position::new(COW_POS),
+                ..Default::default()
+            },
+            Orbit(COW_POS.into()),
+        ))
+        .id();
+
+    commands.spawn((
+        CowBundle {
+            layer: EntityLayerId(layer_id),
+            position: Position::new(COW_POS),
+            ..Default::default()
+        },
+        Riding(cow),
+    ));
+}
+
+fn orbit_entities(
+    server: Res<Server>,
+    mut entities: Query<(&Orbit, &mut Position, &mut Look, &mut HeadYaw)>,
+) {
+    let angle = server.current_tick() as f64 / f64::from(server.tick_rate().get());
+
+    for (orbit, mut pos, mut look, mut head_yaw) in &mut entities {
+        pos.0.x = orbit.0.x + ORBIT_RADIUS * angle.cos();
+        pos.0.z = orbit.0.z + ORBIT_RADIUS * angle.sin();
+        pos.0.y = orbit.0.y;
+
+        let heading = Vec3::new(-(angle.sin() as f32), 0.0, angle.cos() as f32);
+        look.set_vec(heading);
+        head_yaw.0 = look.yaw;
+    }
+}
+
+fn init_clients(
+    mut clients: Query<
+        (
+            &mut EntityLayerId,
+            &mut VisibleChunkLayer,
+            &mut VisibleEntityLayers,
+            &mut Position,
+            &mut GameMode,
+        ),
+        Added<Client>,
+    >,
+    layers: Query<Entity, (With<ChunkLayer>, With<EntityLayer>)>,
+) {
+    for (
+        mut layer_id,
+        mut visible_chunk_layer,
+        mut visible_entity_layers,
+        mut pos,
+        mut game_mode,
+    ) in &mut clients
+    {
+        let layer = layers.single().unwrap();
+
+        layer_id.0 = layer;
+        visible_chunk_layer.0 = layer;
+        visible_entity_layers.0.insert(layer);
+        pos.set([0.0, f64::from(SPAWN_Y) + 1.0, 0.0]);
+        *game_mode = GameMode::Creative;
+    }
+}
+
+fn mount_on_interact(
+    mut commands: Commands,
+    mut events: MessageReader<InteractEntityEvent>,
+    vehicles: Query<(), With<Vehicle>>,
+    riders: Query<Has<Riding>>,
+) {
+    for event in events.read() {
+        if !matches!(event.interact, EntityInteraction::Interact(_)) {
+            continue;
+        }
+
+        if vehicles.get(event.entity).is_err() {
+            continue;
+        }
+
+        let Ok(is_riding) = riders.get(event.client) else {
+            continue;
+        };
+
+        if !is_riding {
+            commands.entity(event.client).insert(Riding(event.entity));
+        }
+    }
+}
+
+fn dismount_on_sneak(
+    mut commands: Commands,
+    mut events: MessageReader<SneakEvent>,
+    riders: Query<Has<Riding>>,
+) {
+    for event in events.read() {
+        if event.state != SneakState::Start {
+            continue;
+        }
+
+        let Ok(is_riding) = riders.get(event.client) else {
+            continue;
+        };
+
+        if is_riding {
+            commands.entity(event.client).remove::<Riding>();
+        }
+    }
+}

--- a/examples/passenger.rs
+++ b/examples/passenger.rs
@@ -139,45 +139,47 @@ fn init_clients(
 
 fn mount_on_interact(
     mut commands: Commands,
-    mut events: MessageReader<InteractEntityEvent>,
+    mut messages: MessageReader<InteractEntityMessage>,
     vehicles: Query<(), With<Vehicle>>,
     riders: Query<Has<Riding>>,
 ) {
-    for event in events.read() {
-        if !matches!(event.interact, EntityInteraction::Interact(_)) {
+    for message in messages.read() {
+        if !matches!(message.interact, EntityInteraction::Interact(_)) {
             continue;
         }
 
-        if vehicles.get(event.entity).is_err() {
+        if vehicles.get(message.entity).is_err() {
             continue;
         }
 
-        let Ok(is_riding) = riders.get(event.client) else {
+        let Ok(is_riding) = riders.get(message.client) else {
             continue;
         };
 
         if !is_riding {
-            commands.entity(event.client).insert(Riding(event.entity));
+            commands
+                .entity(message.client)
+                .insert(Riding(message.entity));
         }
     }
 }
 
 fn dismount_on_sneak(
     mut commands: Commands,
-    mut events: MessageReader<SneakEvent>,
+    mut messages: MessageReader<SneakMessage>,
     riders: Query<Has<Riding>>,
 ) {
-    for event in events.read() {
-        if event.state != SneakState::Start {
+    for message in messages.read() {
+        if message.state != SneakState::Start {
             continue;
         }
 
-        let Ok(is_riding) = riders.get(event.client) else {
+        let Ok(is_riding) = riders.get(message.client) else {
             continue;
         };
 
         if is_riding {
-            commands.entity(event.client).remove::<Riding>();
+            commands.entity(message.client).remove::<Riding>();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ use chunkedge_server::layer::LayerPlugin;
 use chunkedge_server::message::MessagePlugin;
 use chunkedge_server::movement::MovementPlugin;
 use chunkedge_server::op_level::OpLevelPlugin;
+use chunkedge_server::passenger::PassengerPlugin;
 pub use chunkedge_server::protocol::status_effects;
 use chunkedge_server::resource_pack::ResourcePackPlugin;
 use chunkedge_server::status::StatusPlugin;
@@ -162,6 +163,7 @@ pub mod prelude {
     pub use chunkedge_server::math::{DVec2, DVec3, Vec2, Vec3};
     pub use chunkedge_server::message::SendMessage as _;
     pub use chunkedge_server::nbt::Compound;
+    pub use chunkedge_server::passenger::{Passengers, Riding};
     pub use chunkedge_server::protocol::packets::play::level_particles_s2c::Particle;
     pub use chunkedge_server::protocol::text::{Color, IntoText, Text};
     pub use chunkedge_server::protocol::RegistryId;
@@ -203,6 +205,7 @@ impl PluginGroup for DefaultPlugins {
             .add(ClientCommandPlugin)
             .add(KeepalivePlugin)
             .add(InteractEntityPlugin)
+            .add(PassengerPlugin)
             .add(ClientSettingsPlugin)
             .add(ActionPlugin)
             .add(TeleportPlugin)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ mod example;
 mod hunger;
 mod inventory;
 mod layer;
+mod passenger;
 mod player_list;
 mod potions;
 mod scoreboard;

--- a/src/tests/passenger.rs
+++ b/src/tests/passenger.rs
@@ -1,0 +1,200 @@
+use bevy_ecs::prelude::*;
+use chunkedge_server::entity::pig::PigEntityBundle;
+use chunkedge_server::entity::{EntityId, EntityLayerId, Position};
+use chunkedge_server::interact_entity::{EntityInteraction, InteractEntityEvent};
+use chunkedge_server::passenger::{Passengers, Riding};
+use chunkedge_server::protocol::packets::play::{InteractC2s, SetPassengersS2c};
+use chunkedge_server::protocol::VarInt;
+use chunkedge_server::Hand;
+
+use crate::testing::ScenarioSingleClient;
+
+#[test]
+fn passengers_broadcast_on_mount_and_dismount() {
+    let ScenarioSingleClient {
+        mut app,
+        client,
+        mut helper,
+        layer,
+    } = ScenarioSingleClient::new();
+
+    app.update();
+    helper.clear_received();
+
+    let vehicle = app
+        .world_mut()
+        .spawn(PigEntityBundle {
+            layer: EntityLayerId(layer),
+            position: Position::new([0.0, 64.0, 0.0]),
+            ..Default::default()
+        })
+        .id();
+
+    app.update();
+    helper.clear_received();
+
+    app.world_mut().entity_mut(client).insert(Riding(vehicle));
+
+    app.update();
+
+    assert!(
+        app.world().get::<Passengers>(vehicle).is_some(),
+        "vehicle should have a Passengers component after mounting"
+    );
+
+    let recvd = helper.collect_received();
+    recvd.assert_count::<SetPassengersS2c>(1);
+    let pkt = recvd.first::<SetPassengersS2c>();
+    assert_eq!(pkt.passengers.len(), 1, "vehicle should have one passenger");
+    assert_eq!(
+        pkt.passengers[0].0, 0,
+        "the riding client should see its own entity as ID 0 so it mounts itself"
+    );
+
+    helper.clear_received();
+
+    app.world_mut().entity_mut(client).remove::<Riding>();
+
+    app.update();
+
+    assert!(
+        app.world().get::<Passengers>(vehicle).is_none(),
+        "vehicle should lose its Passengers component after the last rider leaves"
+    );
+
+    let recvd = helper.collect_received();
+    recvd.assert_count::<SetPassengersS2c>(1);
+    let pkt = recvd.first::<SetPassengersS2c>();
+    assert_eq!(
+        pkt.passengers.len(),
+        0,
+        "an empty passenger list should be sent on dismount"
+    );
+}
+
+#[test]
+fn passengers_sent_when_vehicle_enters_view() {
+    let ScenarioSingleClient {
+        mut app,
+        client,
+        mut helper,
+        layer,
+    } = ScenarioSingleClient::new();
+
+    app.update();
+    helper.clear_received();
+
+    let far = [1000.0, 64.0, 1000.0];
+
+    let vehicle = app
+        .world_mut()
+        .spawn(PigEntityBundle {
+            layer: EntityLayerId(layer),
+            position: Position::new(far),
+            ..Default::default()
+        })
+        .id();
+    let rider = app
+        .world_mut()
+        .spawn(PigEntityBundle {
+            layer: EntityLayerId(layer),
+            position: Position::new(far),
+            ..Default::default()
+        })
+        .id();
+    app.world_mut().entity_mut(rider).insert(Riding(vehicle));
+
+    app.update();
+    helper.clear_received();
+
+    helper
+        .collect_received()
+        .assert_count::<SetPassengersS2c>(0);
+
+    *app.world_mut().get_mut::<Position>(client).unwrap() = Position::new(far);
+
+    app.update();
+    app.update();
+
+    let recvd = helper.collect_received();
+    recvd.assert_count::<SetPassengersS2c>(1);
+    let pkt = recvd.first::<SetPassengersS2c>();
+    assert_eq!(
+        pkt.passengers.len(),
+        1,
+        "the vehicle should report its rider when it enters a client's view"
+    );
+}
+
+#[derive(Component)]
+struct Vehicle;
+
+fn toggle_ride(
+    mut commands: Commands,
+    mut events: MessageReader<InteractEntityEvent>,
+    vehicles: Query<(), With<Vehicle>>,
+    riders: Query<Has<Riding>>,
+) {
+    for event in events.read() {
+        if !matches!(event.interact, EntityInteraction::Interact(_)) {
+            continue;
+        }
+        if vehicles.get(event.entity).is_err() {
+            continue;
+        }
+        match riders.get(event.client) {
+            Ok(true) => {
+                commands.entity(event.client).remove::<Riding>();
+            }
+            Ok(false) => {
+                commands.entity(event.client).insert(Riding(event.entity));
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+#[test]
+fn right_click_interaction_mounts_the_client() {
+    let ScenarioSingleClient {
+        mut app,
+        client,
+        mut helper,
+        layer,
+    } = ScenarioSingleClient::new();
+
+    app.add_systems(bevy_app::Update, toggle_ride);
+
+    app.update();
+    helper.confirm_initial_pending_teleports();
+    helper.clear_received();
+
+    let vehicle = app
+        .world_mut()
+        .spawn((
+            PigEntityBundle {
+                layer: EntityLayerId(layer),
+                position: Position::new([0.0, 64.0, 0.0]),
+                ..Default::default()
+            },
+            Vehicle,
+        ))
+        .id();
+
+    app.update();
+
+    let vehicle_id = app.world().get::<EntityId>(vehicle).unwrap().get();
+
+    helper.send(&InteractC2s {
+        entity_id: VarInt(vehicle_id),
+        interact: EntityInteraction::Interact(Hand::Main),
+        sneaking: false,
+    });
+
+    app.update();
+
+    assert!(
+        app.world().get::<Riding>(client).is_some(),
+        "client should be riding the vehicle after a right-click interaction"
+    );
+}

--- a/src/tests/passenger.rs
+++ b/src/tests/passenger.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::prelude::*;
 use chunkedge_server::entity::pig::PigEntityBundle;
 use chunkedge_server::entity::{EntityId, EntityLayerId, Position};
-use chunkedge_server::interact_entity::{EntityInteraction, InteractEntityEvent};
+use chunkedge_server::interact_entity::{EntityInteraction, InteractEntityMessage};
 use chunkedge_server::passenger::{Passengers, Riding};
 use chunkedge_server::protocol::packets::play::{InteractC2s, SetPassengersS2c};
 use chunkedge_server::protocol::VarInt;
@@ -131,23 +131,25 @@ struct Vehicle;
 
 fn toggle_ride(
     mut commands: Commands,
-    mut events: MessageReader<InteractEntityEvent>,
+    mut messages: MessageReader<InteractEntityMessage>,
     vehicles: Query<(), With<Vehicle>>,
     riders: Query<Has<Riding>>,
 ) {
-    for event in events.read() {
-        if !matches!(event.interact, EntityInteraction::Interact(_)) {
+    for message in messages.read() {
+        if !matches!(message.interact, EntityInteraction::Interact(_)) {
             continue;
         }
-        if vehicles.get(event.entity).is_err() {
+        if vehicles.get(message.entity).is_err() {
             continue;
         }
-        match riders.get(event.client) {
+        match riders.get(message.client) {
             Ok(true) => {
-                commands.entity(event.client).remove::<Riding>();
+                commands.entity(message.client).remove::<Riding>();
             }
             Ok(false) => {
-                commands.entity(event.client).insert(Riding(event.entity));
+                commands
+                    .entity(message.client)
+                    .insert(Riding(message.entity));
             }
             Err(_) => {}
         }


### PR DESCRIPTION
# Objective

- Add a passenger API
- Closes #28 

# Solution

- Added a passenger module in chunkedge_server.
- Added public `Riding` and `Passenger` components which use Bevy's relationships to keep track of who is a passenger to who.
- Added a passenger example 
