### PR TITLE
Rename all events to messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,9 +111,9 @@ Under appropriate circumstances a different naming scheme can be used. [`Command
 
 If a `bar` field exists and no invariants need to be maintained by the getters and setters, it is usually better to make the `bar` field public.
 
-### Bevy `Event`s
+### Bevy `Message`s
 
-Types intended to be used as events in [`EventReader`] and [`EventWriter`] should end in the `Event` suffix. This is helpful for readers trying to distinguish events from other types in the program.
+Types intended to be used as messages in [`MessageReader`] and [`MessageWriter`] should end in the `Message` suffix. This is helpful for readers trying to distinguish messages from other types in the program.
 
 <table>
 <tr>
@@ -124,9 +124,9 @@ Types intended to be used as events in [`EventReader`] and [`EventWriter`] shoul
 <td>
 
 ```rust
-struct CollisionEvent { ... }
+struct CollisionMessage { ... }
 
-fn handle_collisions(mut events: EventReader<CollisionEvent>) { ... }
+fn handle_collisions(mut messages: MessageReader<CollisionMessage>) { ... }
 ```
 
 </td>
@@ -135,7 +135,7 @@ fn handle_collisions(mut events: EventReader<CollisionEvent>) { ... }
 ```rust
 struct Collision { ... }
 
-fn handle_collisions(mut events: EventReader<Collision>) { ... }
+fn handle_collisions(mut messages: MessageReader<Collision>) { ... }
 ```
 
 </td>

--- a/crates/chunkedge_advancement/src/lib.rs
+++ b/crates/chunkedge_advancement/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-pub mod event;
+pub mod message;
 
 use std::borrow::Cow;
 use std::io::Write;
@@ -21,7 +21,7 @@ use chunkedge_server::protocol::{
 };
 use chunkedge_server::{Ident, ItemStack, Text};
 use derive_more::{Deref, DerefMut};
-use event::{handle_advancement_tab_change, AdvancementTabChangeEvent};
+use message::{handle_advancement_tab_change, AdvancementTabChangeMessage};
 use rustc_hash::FxHashMap;
 
 pub struct AdvancementPlugin;
@@ -41,7 +41,7 @@ impl Plugin for AdvancementPlugin {
                 WriteAdvancementToCacheSet.before(WriteAdvancementPacketToClientsSet),
             ),
         )
-        .add_message::<AdvancementTabChangeEvent>()
+        .add_message::<AdvancementTabChangeMessage>()
         .add_systems(
             PreUpdate,
             (

--- a/crates/chunkedge_advancement/src/message.rs
+++ b/crates/chunkedge_advancement/src/message.rs
@@ -1,23 +1,23 @@
 use bevy_ecs::prelude::*;
-use chunkedge_server::event_loop::PacketEvent;
+use chunkedge_server::event_loop::PacketMessage;
 use chunkedge_server::protocol::packets::play::SeenAdvancementsC2s;
 use chunkedge_server::Ident;
 
-/// This event sends when the client changes or closes advancement's tab.
+/// This message sends when the client changes or closes advancement's tab.
 #[derive(Message, Clone, PartialEq, Eq, Debug)]
-pub struct AdvancementTabChangeEvent {
+pub struct AdvancementTabChangeMessage {
     pub client: Entity,
     /// If None then the client has closed advancement's tabs.
     pub opened_tab: Option<Ident<String>>,
 }
 
 pub(crate) fn handle_advancement_tab_change(
-    mut packets: MessageReader<PacketEvent>,
-    mut advancement_tab_change_events: MessageWriter<AdvancementTabChangeEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut advancement_tab_change_messages: MessageWriter<AdvancementTabChangeMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<SeenAdvancementsC2s>() {
-            advancement_tab_change_events.write(AdvancementTabChangeEvent {
+            advancement_tab_change_messages.write(AdvancementTabChangeMessage {
                 client: packet.client,
                 opened_tab: match pkt {
                     SeenAdvancementsC2s::ClosedScreen => None,

--- a/crates/chunkedge_anvil/src/bevy.rs
+++ b/crates/chunkedge_anvil/src/bevy.rs
@@ -94,8 +94,8 @@ pub struct AnvilPlugin;
 
 impl Plugin for AnvilPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<ChunkLoadEvent>()
-            .add_message::<ChunkUnloadEvent>()
+        app.add_message::<ChunkLoadMessage>()
+            .add_message::<ChunkUnloadMessage>()
             .add_systems(PreUpdate, remove_unviewed_chunks)
             .add_systems(
                 PostUpdate,
@@ -120,14 +120,14 @@ fn init_anvil(mut query: Query<&mut AnvilLevel, (Added<AnvilLevel>, With<ChunkLa
 /// updated from the previous tick.
 fn remove_unviewed_chunks(
     mut chunk_layers: Query<(Entity, &mut ChunkLayer, &AnvilLevel)>,
-    mut unload_events: MessageWriter<ChunkUnloadEvent>,
+    mut unload_messages: MessageWriter<ChunkUnloadMessage>,
 ) {
     for (entity, mut layer, anvil) in &mut chunk_layers {
         layer.retain_chunks(|pos, chunk| {
             if chunk.viewer_count_mut() > 0 || anvil.ignored_chunks.contains(&pos) {
                 true
             } else {
-                unload_events.write(ChunkUnloadEvent {
+                unload_messages.write(ChunkUnloadMessage {
                     chunk_layer: entity,
                     pos,
                 });
@@ -181,13 +181,13 @@ fn update_client_views(
 fn send_recv_chunks(
     mut layers: Query<(Entity, &mut ChunkLayer, &mut AnvilLevel)>,
     mut to_send: Local<Vec<(Priority, ChunkPos)>>,
-    mut load_events: MessageWriter<ChunkLoadEvent>,
+    mut load_messages: MessageWriter<ChunkLoadMessage>,
 ) {
     for (entity, mut layer, anvil) in &mut layers {
         let anvil = anvil.into_inner();
 
         // Insert the chunks that are finished loading into the chunk layer and send
-        // load events.
+        // load messages.
         for (pos, res) in anvil.receiver.drain() {
             anvil.pending.remove(&pos);
 
@@ -200,7 +200,7 @@ fn send_recv_chunks(
                 Err(e) => ChunkLoadStatus::Failed(e),
             };
 
-            load_events.write(ChunkLoadEvent {
+            load_messages.write(ChunkLoadMessage {
                 chunk_layer: entity,
                 pos,
                 status,
@@ -235,9 +235,9 @@ fn anvil_worker(mut state: ChunkWorkerState) {
     }
 }
 
-/// An event sent by `chunkedge_anvil` after an attempt to load a chunk is made.
+/// A message sent by `chunkedge_anvil` after an attempt to load a chunk is made.
 #[derive(Message, Debug)]
-pub struct ChunkLoadEvent {
+pub struct ChunkLoadMessage {
     /// The [`ChunkLayer`] where the chunk is located.
     pub chunk_layer: Entity,
     /// The position of the chunk in the layer.
@@ -260,9 +260,9 @@ pub enum ChunkLoadStatus {
     Failed(anyhow::Error),
 }
 
-/// An event sent by `chunkedge_anvil` when a chunk is unloaded from an layer.
+/// A message sent by `chunkedge_anvil` when a chunk is unloaded from an layer.
 #[derive(Message, Debug)]
-pub struct ChunkUnloadEvent {
+pub struct ChunkUnloadMessage {
     /// The [`ChunkLayer`] where the chunk was unloaded.
     pub chunk_layer: Entity,
     /// The position of the chunk that was unloaded.

--- a/crates/chunkedge_command/README.md
+++ b/crates/chunkedge_command/README.md
@@ -6,7 +6,7 @@ dispatching commands.
 #### This plugin manages the following:
 
 - Registering commands to a Command Graph which is used parse commands.
-- Receiving commands from the client and turning them into events.
+- Receiving commands from the client and turning them into messages.
 - Parsing commands and dispatching them in the registered executable format.
 - Sending the command graph to clients.
 

--- a/crates/chunkedge_command/src/handler.rs
+++ b/crates/chunkedge_command/src/handler.rs
@@ -12,7 +12,7 @@ use crate::graph::CommandGraphBuilder;
 use crate::modifier_value::ModifierValue;
 use crate::parsers::ParseInput;
 use crate::{
-    Command, CommandProcessedEvent, CommandRegistry, CommandScopeRegistry, CommandSystemSet,
+    Command, CommandProcessedMessage, CommandRegistry, CommandScopeRegistry, CommandSystemSet,
 };
 
 impl<T> Plugin for CommandHandlerPlugin<T>
@@ -20,12 +20,12 @@ where
     T: Command + Send + Sync + 'static,
 {
     fn build(&self, app: &mut App) {
-        app.add_message::<CommandResultEvent<T>>()
+        app.add_message::<CommandResultMessage<T>>()
             .insert_resource(CommandResource::<T>::new())
             .add_systems(PostStartup, command_startup_system::<T>)
             .add_systems(
                 EventLoopPreUpdate,
-                command_event_system::<T>.after(CommandSystemSet),
+                command_message_system::<T>.after(CommandSystemSet),
             );
     }
 }
@@ -70,7 +70,7 @@ impl<T: Command + Send + Sync> CommandResource<T> {
 }
 
 #[derive(Message)]
-pub struct CommandResultEvent<T>
+pub struct CommandResultMessage<T>
 where
     T: Command,
     T: Send + Sync + 'static,
@@ -105,21 +105,21 @@ fn command_startup_system<T>(
     registry.executables.extend(executables.keys());
 }
 
-/// This system reads incoming command events.
-fn command_event_system<T>(
-    mut commands_executed: MessageReader<CommandProcessedEvent>,
-    mut events: MessageWriter<CommandResultEvent<T>>,
+/// This system reads incoming command messages.
+fn command_message_system<T>(
+    mut commands_executed: MessageReader<CommandProcessedMessage>,
+    mut messages: MessageWriter<CommandResultMessage<T>>,
     command: ResMut<CommandResource<T>>,
 ) where
     T: Command + Send + Sync,
 {
-    for command_event in commands_executed.read() {
-        if let Some(executable) = command.executables.get(&command_event.node) {
-            let result = executable(&mut ParseInput::new(&command_event.command));
-            events.write(CommandResultEvent {
+    for command_message in commands_executed.read() {
+        if let Some(executable) = command.executables.get(&command_message.node) {
+            let result = executable(&mut ParseInput::new(&command_message.command));
+            messages.write(CommandResultMessage {
                 result,
-                executor: command_event.executor,
-                modifiers: command_event.modifiers.clone(),
+                executor: command_message.executor,
+                modifiers: command_message.modifiers.clone(),
             });
         }
     }

--- a/crates/chunkedge_command/src/lib.rs
+++ b/crates/chunkedge_command/src/lib.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 
 use bevy_app::App;
 use bevy_ecs::prelude::{Resource, SystemSet};
-pub use manager::{CommandExecutionEvent, CommandProcessedEvent};
+pub use manager::{CommandExecutionMessage, CommandProcessedMessage};
 pub use modifier_value::ModifierValue;
 use petgraph::prelude::NodeIndex;
 pub use scopes::CommandScopeRegistry;

--- a/crates/chunkedge_command/src/manager.rs
+++ b/crates/chunkedge_command/src/manager.rs
@@ -7,7 +7,7 @@ use bevy_ecs::prelude::{
     MessageWriter, Mut, Or, Query, Res,
 };
 use chunkedge_server::client::{Client, SpawnClientsSet};
-use chunkedge_server::event_loop::PacketEvent;
+use chunkedge_server::event_loop::PacketMessage;
 use chunkedge_server::protocol::packets::play::commands_s2c::NodeData;
 use chunkedge_server::protocol::packets::play::{
     ChatCommandC2s, ChatCommandSignedC2s, CommandsS2c,
@@ -29,8 +29,8 @@ pub struct CommandPlugin;
 impl Plugin for CommandPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(CommandScopePlugin)
-            .add_message::<CommandExecutionEvent>()
-            .add_message::<CommandProcessedEvent>()
+            .add_message::<CommandExecutionMessage>()
+            .add_message::<CommandProcessedMessage>()
             .add_systems(PreUpdate, insert_scope_component.after(SpawnClientsSet))
             .add_systems(
                 EventLoopPreUpdate,
@@ -56,10 +56,10 @@ impl Plugin for CommandPlugin {
     }
 }
 
-/// This event is sent when a command is sent (you can send this with any
+/// This message is sent when a command is sent (you can send this with any
 /// entity)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Message)]
-pub struct CommandExecutionEvent {
+pub struct CommandExecutionMessage {
     /// the command that was executed eg. "teleport @p 0 ~ 0"
     pub command: String,
     /// usually the Client entity but it could be a command block or something
@@ -70,7 +70,7 @@ pub struct CommandExecutionEvent {
 /// This will only be sent if the command was successfully parsed and an
 /// executable was found
 #[derive(Debug, Clone, PartialEq, Eq, Message)]
-pub struct CommandProcessedEvent {
+pub struct CommandProcessedMessage {
     /// the command that was executed eg. "teleport @p 0 ~ 0"
     pub command: String,
     /// usually the Client entity but it could be a command block or something
@@ -89,14 +89,14 @@ fn insert_scope_component(mut clients: Query<Entity, Added<Client>>, mut command
 }
 
 fn read_incoming_packets(
-    mut packets: MessageReader<PacketEvent>,
-    mut event_writer: MessageWriter<CommandExecutionEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut message_writer: MessageWriter<CommandExecutionMessage>,
 ) {
     for packet in packets.read() {
         let client = packet.client;
 
         if let Some(unsigned) = packet.decode::<ChatCommandC2s>() {
-            event_writer.write(CommandExecutionEvent {
+            message_writer.write(CommandExecutionMessage {
                 command: unsigned.command.to_string(),
                 executor: client,
             });
@@ -105,7 +105,7 @@ fn read_incoming_packets(
             // As per this gist: https://gist.github.com/kennytv/ed783dd244ca0321bbd882c347892874
             // It looks like the client only sends the signed version if a command requires
             // it (in vanilla thats /say for example).
-            event_writer.write(CommandExecutionEvent {
+            message_writer.write(CommandExecutionMessage {
                 command: signed.command.to_string(),
                 executor: client,
             });
@@ -226,14 +226,14 @@ fn update_client_command_tree(
 }
 
 fn parse_incoming_commands(
-    mut event_reader: MessageReader<CommandExecutionEvent>,
-    mut event_writer: MessageWriter<CommandProcessedEvent>,
+    mut message_reader: MessageReader<CommandExecutionMessage>,
+    mut message_writer: MessageWriter<CommandProcessedMessage>,
     command_registry: Res<CommandRegistry>,
     scope_registry: Res<CommandScopeRegistry>,
     entity_scopes: Query<&CommandScopes>,
 ) {
-    for command_event in event_reader.read() {
-        let executor = command_event.executor;
+    for command_message in message_reader.read() {
+        let executor = command_message.executor;
         // these are the leafs of the graph that are executable under this command
         // group
         let executable_leafs = command_registry
@@ -242,7 +242,7 @@ fn parse_incoming_commands(
             .collect::<Vec<&NodeIndex>>();
         let root = command_registry.graph.root;
 
-        let command_input = &*command_event.command;
+        let command_input = &*command_message.command;
         let graph = &command_registry.graph.graph;
         let input = ParseInput::new(command_input);
 
@@ -273,7 +273,7 @@ fn parse_incoming_commands(
 
         for node in to_be_executed {
             trace!("executing node: {node:?}");
-            event_writer.write(CommandProcessedEvent {
+            message_writer.write(CommandProcessedMessage {
                 command: args.join(" "),
                 executor,
                 modifiers: modifiers.clone(),
@@ -282,7 +282,7 @@ fn parse_incoming_commands(
         }
         info!(
             "Command dispatched: /{} (debug logs for more data)",
-            command_event.command
+            command_message.command
         );
         debug!("Command modifiers: {:?}", modifiers);
     }

--- a/crates/chunkedge_equipment/src/interaction_broadcast.rs
+++ b/crates/chunkedge_equipment/src/interaction_broadcast.rs
@@ -1,7 +1,7 @@
 use chunkedge_inventory::{HeldItem, Inventory, PlayerAction};
 use chunkedge_server::entity::living::LivingFlags;
-use chunkedge_server::event_loop::PacketEvent;
-use chunkedge_server::interact_item::InteractItemEvent;
+use chunkedge_server::event_loop::PacketMessage;
+use chunkedge_server::interact_item::InteractItemMessage;
 use chunkedge_server::protocol::packets::play::PlayerActionC2s;
 use chunkedge_server::ItemKind;
 
@@ -19,10 +19,10 @@ pub(crate) fn start_interaction(
         (&Inventory, &HeldItem, &mut LivingFlags),
         (With<Client>, With<EquipmentInteractionBroadcast>),
     >,
-    mut events: MessageReader<InteractItemEvent>,
+    mut messages: MessageReader<InteractItemMessage>,
 ) {
-    for event in events.read() {
-        if let Ok((inv, held_item, mut flags)) = clients.get_mut(event.client) {
+    for message in messages.read() {
+        if let Ok((inv, held_item, mut flags)) = clients.get_mut(message.client) {
             let item = inv.slot(held_item.slot()).item;
             let has_arrows = inv.first_slot_with_item(ItemKind::Arrow, i8::MAX).is_some();
             if (item == ItemKind::Bow && !has_arrows)
@@ -41,7 +41,7 @@ pub(crate) fn start_interaction(
 // item.
 pub(crate) fn stop_interaction(
     mut clients: Query<&mut LivingFlags, (With<Client>, With<EquipmentInteractionBroadcast>)>,
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<PlayerActionC2s>() {

--- a/crates/chunkedge_equipment/src/inventory_sync.rs
+++ b/crates/chunkedge_equipment/src/inventory_sync.rs
@@ -1,5 +1,5 @@
 use chunkedge_inventory::player_inventory::PlayerInventory;
-use chunkedge_inventory::{HeldItem, Inventory, UpdateSelectedSlotEvent};
+use chunkedge_inventory::{HeldItem, Inventory, UpdateSelectedSlotMessage};
 use chunkedge_server::entity::player::PlayerEntity;
 
 use super::*;
@@ -67,10 +67,10 @@ pub(crate) fn equipment_inventory_sync(
 /// suppressed for this)
 pub(crate) fn equipment_held_item_sync_from_client(
     mut clients: Query<(&HeldItem, &Inventory, &mut Equipment), With<EquipmentInventorySync>>,
-    mut events: MessageReader<UpdateSelectedSlotEvent>,
+    mut messages: MessageReader<UpdateSelectedSlotMessage>,
 ) {
-    for event in events.read() {
-        let Ok((held_item, inventory, mut equipment)) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok((held_item, inventory, mut equipment)) = clients.get_mut(message.client) else {
             continue;
         };
 

--- a/crates/chunkedge_equipment/src/lib.rs
+++ b/crates/chunkedge_equipment/src/lib.rs
@@ -5,7 +5,7 @@ use bevy_ecs::prelude::*;
 mod interaction_broadcast;
 pub use interaction_broadcast::EquipmentInteractionBroadcast;
 mod inventory_sync;
-use chunkedge_server::client::{Client, FlushPacketsSet, LoadEntityForClientEvent};
+use chunkedge_server::client::{Client, FlushPacketsSet, LoadEntityForClientMessage};
 use chunkedge_server::entity::living::LivingEntity;
 use chunkedge_server::entity::{EntityId, EntityLayerId, Position};
 use chunkedge_server::protocol::packets::play::set_equipment_s2c::{EquipmentEntry, EquipmentSlot};
@@ -36,7 +36,7 @@ impl Plugin for EquipmentPlugin {
                 on_entity_load.before(FlushPacketsSet),
             ),
         )
-        .add_message::<EquipmentChangeEvent>();
+        .add_message::<EquipmentChangeMessage>();
     }
 }
 
@@ -181,7 +181,7 @@ pub struct EquipmentSlotChange {
 }
 
 #[derive(Debug, Clone, Message)]
-pub struct EquipmentChangeEvent {
+pub struct EquipmentChangeMessage {
     pub client: Entity,
     pub changed: Vec<EquipmentSlotChange>,
 }
@@ -191,7 +191,7 @@ fn update_equipment(
         (Entity, &EntityId, &EntityLayerId, &Position, &mut Equipment),
         Changed<Equipment>,
     >,
-    mut event_writer: MessageWriter<EquipmentChangeEvent>,
+    mut message_writer: MessageWriter<EquipmentChangeMessage>,
     mut entity_layer: Query<&mut EntityLayer>,
 ) {
     for (entity, entity_id, entity_layer_id, position, mut equipment) in &mut clients {
@@ -225,7 +225,7 @@ fn update_equipment(
                         .collect(),
                 });
 
-            event_writer.write(EquipmentChangeEvent {
+            message_writer.write(EquipmentChangeMessage {
                 client: entity,
                 changed: slots_changed,
             });
@@ -240,14 +240,14 @@ fn update_equipment(
 fn on_entity_load(
     mut clients: Query<&mut Client>,
     entities: Query<(&EntityId, &Equipment)>,
-    mut events: MessageReader<LoadEntityForClientEvent>,
+    mut messages: MessageReader<LoadEntityForClientMessage>,
 ) {
-    for event in events.read() {
-        let Ok(mut client) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok(mut client) = clients.get_mut(message.client) else {
             continue;
         };
 
-        let Ok((entity_id, equipment)) = entities.get(event.entity_loaded) else {
+        let Ok((entity_id, equipment)) = entities.get(message.entity_loaded) else {
             continue;
         };
 

--- a/crates/chunkedge_inventory/src/lib.rs
+++ b/crates/chunkedge_inventory/src/lib.rs
@@ -8,8 +8,8 @@ use std::ops::Range;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use chunkedge_server::client::{Client, FlushPacketsSet, SpawnClientsSet};
-use chunkedge_server::event_loop::{EventLoopPreUpdate, PacketEvent};
-use chunkedge_server::interact_block::InteractBlockEvent;
+use chunkedge_server::event_loop::{EventLoopPreUpdate, PacketMessage};
+use chunkedge_server::interact_block::InteractBlockMessage;
 pub use chunkedge_server::protocol::packets::play::container_click_c2s::{ClickMode, SlotChange};
 use chunkedge_server::protocol::packets::play::open_screen_s2c::WindowType;
 pub use chunkedge_server::protocol::packets::play::player_action_c2s::PlayerAction;
@@ -59,10 +59,10 @@ impl Plugin for InventoryPlugin {
             ),
         )
         .init_resource::<InventorySettings>()
-        .add_message::<ClickSlotEvent>()
-        .add_message::<DropItemStackEvent>()
-        .add_message::<CreativeInventoryActionEvent>()
-        .add_message::<UpdateSelectedSlotEvent>();
+        .add_message::<ClickSlotMessage>()
+        .add_message::<DropItemStackMessage>()
+        .add_message::<CreativeInventoryActionMessage>()
+        .add_message::<UpdateSelectedSlotMessage>();
     }
 }
 
@@ -819,7 +819,7 @@ fn update_cursor_item(
 }
 
 /// Handles clients telling the server that they are closing an inventory.
-fn handle_close_handled_screen(mut packets: MessageReader<PacketEvent>, mut commands: Commands) {
+fn handle_close_handled_screen(mut packets: MessageReader<PacketMessage>, mut commands: Commands) {
     for packet in packets.read() {
         if packet.decode::<ContainerCloseC2s>().is_some() {
             if let Ok(mut entity) = commands.get_entity(packet.client) {
@@ -844,9 +844,9 @@ fn update_client_on_close_inventory(
     }
 }
 
-// TODO: make this event user friendly.
+// TODO: make this message user friendly.
 #[derive(Message, Clone, Debug)]
-pub struct ClickSlotEvent {
+pub struct ClickSlotMessage {
     pub client: Entity,
     pub window_id: VarInt,
     pub state_id: i32,
@@ -858,14 +858,14 @@ pub struct ClickSlotEvent {
 }
 
 #[derive(Message, Clone, Debug)]
-pub struct DropItemStackEvent {
+pub struct DropItemStackMessage {
     pub client: Entity,
     pub from_slot: Option<u16>,
     pub stack: ItemStack,
 }
 
 fn handle_click_slot(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(
         &mut Client,
         &mut Inventory,
@@ -874,8 +874,8 @@ fn handle_click_slot(
         &mut CursorItem,
     )>,
     mut inventories: Query<&mut Inventory, Without<Client>>,
-    mut drop_item_stack_events: MessageWriter<DropItemStackEvent>,
-    mut click_slot_events: MessageWriter<ClickSlotEvent>,
+    mut drop_item_stack_messages: MessageWriter<DropItemStackMessage>,
+    mut click_slot_messages: MessageWriter<ClickSlotMessage>,
 ) {
     for packet in packets.read() {
         let Some(pkt) = packet.decode::<ContainerClickC2s>() else {
@@ -930,7 +930,7 @@ fn handle_click_slot(
             let stack = std::mem::take(&mut cursor_item.0);
 
             if !stack.is_empty() {
-                drop_item_stack_events.write(DropItemStackEvent {
+                drop_item_stack_messages.write(DropItemStackMessage {
                     client: packet.client,
                     from_slot: None,
                     stack,
@@ -1006,7 +1006,7 @@ fn handle_click_slot(
                             old_slot
                         };
 
-                        drop_item_stack_events.write(DropItemStackEvent {
+                        drop_item_stack_messages.write(DropItemStackMessage {
                             client: packet.client,
                             from_slot: Some(pkt.slot_idx as u16),
                             stack: dropped,
@@ -1043,7 +1043,7 @@ fn handle_click_slot(
                             old_slot
                         };
 
-                        drop_item_stack_events.write(DropItemStackEvent {
+                        drop_item_stack_messages.write(DropItemStackMessage {
                             client: packet.client,
                             from_slot: Some(slot_id),
                             stack: dropped,
@@ -1088,7 +1088,7 @@ fn handle_click_slot(
                         old_slot
                     };
 
-                    drop_item_stack_events.write(DropItemStackEvent {
+                    drop_item_stack_messages.write(DropItemStackMessage {
                         client: packet.client,
                         from_slot: Some(pkt.slot_idx as u16),
                         stack: dropped,
@@ -1244,7 +1244,7 @@ fn handle_click_slot(
                 }
             }
 
-            click_slot_events.write(ClickSlotEvent {
+            click_slot_messages.write(ClickSlotMessage {
                 client: packet.client,
                 window_id: pkt.window_id,
                 state_id: pkt.state_id.0,
@@ -1259,14 +1259,14 @@ fn handle_click_slot(
 }
 
 fn handle_player_actions(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(
         &mut Inventory,
         &mut ClientInventoryState,
         &HeldItem,
         &mut Client,
     )>,
-    mut drop_item_stack_events: MessageWriter<DropItemStackEvent>,
+    mut drop_item_stack_messages: MessageWriter<DropItemStackMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<PlayerActionC2s>() {
@@ -1291,7 +1291,7 @@ fn handle_player_actions(
                         if !stack.is_empty() {
                             inv_state.slots_changed |= 1 << held.slot();
 
-                            drop_item_stack_events.write(DropItemStackEvent {
+                            drop_item_stack_messages.write(DropItemStackMessage {
                                 client: packet.client,
                                 from_slot: Some(held.slot()),
                                 stack,
@@ -1328,7 +1328,7 @@ fn handle_player_actions(
 
                             inv_state.slots_changed |= 1 << held.slot();
 
-                            drop_item_stack_events.write(DropItemStackEvent {
+                            drop_item_stack_messages.write(DropItemStackMessage {
                                 client: packet.client,
                                 from_slot: Some(held.slot()),
                                 stack,
@@ -1365,10 +1365,10 @@ fn handle_player_actions(
 /// it will be desynced, therefore we set the slot as changed.
 fn resync_readonly_inventory_after_block_interaction(
     mut clients: Query<(&mut Inventory, &HeldItem)>,
-    mut events: MessageReader<InteractBlockEvent>,
+    mut messages: MessageReader<InteractBlockMessage>,
 ) {
-    for event in events.read() {
-        let Ok((mut inventory, held_item)) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok((mut inventory, held_item)) = clients.get_mut(message.client) else {
             continue;
         };
 
@@ -1376,7 +1376,7 @@ fn resync_readonly_inventory_after_block_interaction(
             continue;
         }
 
-        let slot = if event.hand == Hand::Main {
+        let slot = if message.hand == Hand::Main {
             held_item.slot()
         } else {
             PlayerInventory::SLOT_OFFHAND
@@ -1390,24 +1390,24 @@ fn resync_readonly_inventory_after_block_interaction(
     }
 }
 
-// TODO: make this event user friendly.
+// TODO: make this message user friendly.
 #[derive(Message, Clone, Debug)]
-pub struct CreativeInventoryActionEvent {
+pub struct CreativeInventoryActionMessage {
     pub client: Entity,
     pub slot: i16,
     pub clicked_item: ItemStack,
 }
 
 fn handle_creative_inventory_action(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(
         &mut Client,
         &mut Inventory,
         &mut ClientInventoryState,
         &GameMode,
     )>,
-    mut inv_action_events: MessageWriter<CreativeInventoryActionEvent>,
-    mut drop_item_stack_events: MessageWriter<DropItemStackEvent>,
+    mut inv_action_messages: MessageWriter<CreativeInventoryActionMessage>,
+    mut drop_item_stack_messages: MessageWriter<DropItemStackMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<SetCreativeModeSlotC2s>() {
@@ -1426,7 +1426,7 @@ fn handle_creative_inventory_action(
                 let stack = pkt.clicked_item.clone();
 
                 if !stack.is_empty() {
-                    drop_item_stack_events.write(DropItemStackEvent {
+                    drop_item_stack_messages.write(DropItemStackMessage {
                         client: packet.client,
                         from_slot: None,
                         stack,
@@ -1456,7 +1456,7 @@ fn handle_creative_inventory_action(
                 slot_data: Cow::Borrowed(&pkt.clicked_item),
             });
 
-            inv_action_events.write(CreativeInventoryActionEvent {
+            inv_action_messages.write(CreativeInventoryActionMessage {
                 client: packet.client,
                 slot: pkt.slot,
                 clicked_item: pkt.clicked_item,
@@ -1466,7 +1466,7 @@ fn handle_creative_inventory_action(
 }
 
 #[derive(Message, Clone, Debug)]
-pub struct UpdateSelectedSlotEvent {
+pub struct UpdateSelectedSlotMessage {
     pub client: Entity,
     pub slot: u8,
 }
@@ -1483,9 +1483,9 @@ fn update_player_selected_slot(mut clients: Query<(&mut Client, &HeldItem), Chan
 
 /// Client to Server `HeldItem` Slot
 fn handle_update_selected_slot(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<&mut HeldItem>,
-    mut events: MessageWriter<UpdateSelectedSlotEvent>,
+    mut messages: MessageWriter<UpdateSelectedSlotMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<SetCarriedItemC2s>() {
@@ -1501,7 +1501,7 @@ fn handle_update_selected_slot(
 
                 held.set_hotbar_idx(pkt.slot as u8);
 
-                events.write(UpdateSelectedSlotEvent {
+                messages.write(UpdateSelectedSlotMessage {
                     client: packet.client,
                     slot: pkt.slot as u8,
                 });

--- a/crates/chunkedge_server/src/abilities.rs
+++ b/crates/chunkedge_server/src/abilities.rs
@@ -6,7 +6,7 @@ use chunkedge_protocol::{GameMode, WritePacket};
 use derive_more::{Deref, DerefMut};
 
 use crate::client::{update_game_mode, Client, UpdateClientsSet};
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 /// [`Component`] that stores the player's flying speed ability.
 ///
@@ -35,13 +35,13 @@ impl Default for FovModifier {
 
 /// Send if the client sends [`PlayerAbilitiesC2s::StartFlying`]
 #[derive(Message)]
-pub struct PlayerStartFlyingEvent {
+pub struct PlayerStartFlyingMessage {
     pub client: Entity,
 }
 
 /// Send if the client sends [`PlayerAbilitiesC2s::StopFlying`]
 #[derive(Message)]
-pub struct PlayerStopFlyingEvent {
+pub struct PlayerStopFlyingMessage {
     pub client: Entity,
 }
 
@@ -62,8 +62,8 @@ pub struct AbilitiesPlugin;
 
 impl Plugin for AbilitiesPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<PlayerStartFlyingEvent>()
-            .add_message::<PlayerStopFlyingEvent>()
+        app.add_message::<PlayerStartFlyingMessage>()
+            .add_message::<PlayerStopFlyingMessage>()
             .add_systems(
                 PostUpdate,
                 (
@@ -104,8 +104,8 @@ fn update_client_player_abilities(
 /// /!\ This system does not trigger change detection on
 /// [`PlayerAbilitiesFlags`]
 fn update_player_abilities(
-    mut player_start_flying_event_writer: MessageWriter<PlayerStartFlyingEvent>,
-    mut player_stop_flying_event_writer: MessageWriter<PlayerStopFlyingEvent>,
+    mut player_start_flying_message_writer: MessageWriter<PlayerStartFlyingMessage>,
+    mut player_stop_flying_message_writer: MessageWriter<PlayerStopFlyingMessage>,
     mut client_query: Query<(Entity, &mut PlayerAbilitiesFlags, &GameMode), Changed<GameMode>>,
 ) {
     for (entity, mut mut_flags, gamemode) in &mut client_query {
@@ -121,21 +121,22 @@ fn update_player_abilities(
                 flags.set_allow_flying(true);
                 flags.set_instant_break(false);
                 flags.set_flying(true);
-                player_start_flying_event_writer.write(PlayerStartFlyingEvent { client: entity });
+                player_start_flying_message_writer
+                    .write(PlayerStartFlyingMessage { client: entity });
             }
             GameMode::Survival => {
                 flags.set_invulnerable(false);
                 flags.set_allow_flying(false);
                 flags.set_instant_break(false);
                 flags.set_flying(false);
-                player_stop_flying_event_writer.write(PlayerStopFlyingEvent { client: entity });
+                player_stop_flying_message_writer.write(PlayerStopFlyingMessage { client: entity });
             }
             GameMode::Adventure => {
                 flags.set_invulnerable(false);
                 flags.set_allow_flying(false);
                 flags.set_instant_break(false);
                 flags.set_flying(false);
-                player_stop_flying_event_writer.write(PlayerStopFlyingEvent { client: entity });
+                player_stop_flying_message_writer.write(PlayerStopFlyingMessage { client: entity });
             }
         }
     }
@@ -144,25 +145,25 @@ fn update_player_abilities(
 /// /!\ This system does not trigger change detection on
 /// [`PlayerAbilitiesFlags`]
 fn update_server_player_abilities(
-    mut packet_events: MessageReader<PacketEvent>,
-    mut player_start_flying_event_writer: MessageWriter<PlayerStartFlyingEvent>,
-    mut player_stop_flying_event_writer: MessageWriter<PlayerStopFlyingEvent>,
+    mut packet_messages: MessageReader<PacketMessage>,
+    mut player_start_flying_message_writer: MessageWriter<PlayerStartFlyingMessage>,
+    mut player_stop_flying_message_writer: MessageWriter<PlayerStopFlyingMessage>,
     mut client_query: Query<&mut PlayerAbilitiesFlags>,
 ) {
-    for packets in packet_events.read() {
+    for packets in packet_messages.read() {
         if let Some(pkt) = packets.decode::<PlayerAbilitiesC2s>() {
             if let Ok(mut mut_flags) = client_query.get_mut(packets.client) {
                 let flags = mut_flags.bypass_change_detection();
                 match pkt {
                     PlayerAbilitiesC2s::StartFlying => {
                         flags.set_flying(true);
-                        player_start_flying_event_writer.write(PlayerStartFlyingEvent {
+                        player_start_flying_message_writer.write(PlayerStartFlyingMessage {
                             client: packets.client,
                         });
                     }
                     PlayerAbilitiesC2s::StopFlying => {
                         flags.set_flying(false);
-                        player_stop_flying_event_writer.write(PlayerStopFlyingEvent {
+                        player_stop_flying_message_writer.write(PlayerStopFlyingMessage {
                             client: packets.client,
                         });
                     }

--- a/crates/chunkedge_server/src/action.rs
+++ b/crates/chunkedge_server/src/action.rs
@@ -6,13 +6,13 @@ use chunkedge_protocol::{BlockPos, Direction, VarInt, WritePacket};
 use derive_more::Deref;
 
 use crate::client::{Client, UpdateClientsSet};
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct ActionPlugin;
 
 impl Plugin for ActionPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<DiggingEvent>()
+        app.add_message::<DiggingMessage>()
             .add_systems(EventLoopPreUpdate, handle_player_action)
             .add_systems(
                 PostUpdate,
@@ -22,7 +22,7 @@ impl Plugin for ActionPlugin {
 }
 
 #[derive(Message, Copy, Clone, Debug)]
-pub struct DiggingEvent {
+pub struct DiggingMessage {
     pub client: Entity,
     pub position: BlockPos,
     pub direction: Direction,
@@ -51,8 +51,8 @@ impl ActionSequence {
 
 fn handle_player_action(
     mut clients: Query<&mut ActionSequence>,
-    mut packets: MessageReader<PacketEvent>,
-    mut digging_events: MessageWriter<DiggingEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut digging_messages: MessageWriter<DiggingMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<PlayerActionC2s>() {
@@ -65,7 +65,7 @@ fn handle_player_action(
 
             match pkt.action {
                 PlayerAction::StartDestroyBlock => {
-                    digging_events.write(DiggingEvent {
+                    digging_messages.write(DiggingMessage {
                         client: packet.client,
                         position: pkt.position,
                         direction: pkt.direction,
@@ -73,7 +73,7 @@ fn handle_player_action(
                     });
                 }
                 PlayerAction::AbortDestroyBlock => {
-                    digging_events.write(DiggingEvent {
+                    digging_messages.write(DiggingMessage {
                         client: packet.client,
                         position: pkt.position,
                         direction: pkt.direction,
@@ -81,7 +81,7 @@ fn handle_player_action(
                     });
                 }
                 PlayerAction::StopDestroyBlock => {
-                    digging_events.write(DiggingEvent {
+                    digging_messages.write(DiggingMessage {
                         client: packet.client,
                         position: pkt.position,
                         direction: pkt.direction,

--- a/crates/chunkedge_server/src/client.rs
+++ b/crates/chunkedge_server/src/client.rs
@@ -105,8 +105,8 @@ impl Plugin for ClientPlugin {
                 FlushPacketsSet,
             ),
         )
-        .add_message::<LoadEntityForClientEvent>()
-        .add_message::<UnloadEntityForClientEvent>();
+        .add_message::<LoadEntityForClientMessage>()
+        .add_message::<UnloadEntityForClientMessage>();
     }
 }
 
@@ -910,20 +910,20 @@ fn handle_layer_messages(
     );
 }
 
-/// This event will be emitted when a entity is unloaded for a client (e.g when
+/// This message will be emitted when a entity is unloaded for a client (e.g when
 /// moving out of range of the entity).
 #[derive(Debug, Clone, PartialEq, Message)]
-pub struct UnloadEntityForClientEvent {
+pub struct UnloadEntityForClientMessage {
     /// The client to unload the entity for.
     pub client: Entity,
     /// The entity ID of the entity that will be unloaded.
     pub entity_unloaded: Entity,
 }
 
-/// This event will be emitted when a entity is loaded for a client (e.g when
+/// This message will be emitted when a entity is loaded for a client (e.g when
 /// moving into range of the entity).
 #[derive(Debug, Clone, PartialEq, Message)]
-pub struct LoadEntityForClientEvent {
+pub struct LoadEntityForClientMessage {
     /// The client to load the entity for.
     pub client: Entity,
     /// The entity that will be loaded.
@@ -957,13 +957,13 @@ pub(crate) fn update_view_and_layers(
     entity_ids: Query<&EntityId>,
     entity_init: Query<(EntityInitQuery, &Position)>,
 
-    mut unload_entity_writer: MessageWriter<UnloadEntityForClientEvent>,
-    mut load_entity_writer: MessageWriter<LoadEntityForClientEvent>,
+    mut unload_entity_writer: MessageWriter<UnloadEntityForClientMessage>,
+    mut load_entity_writer: MessageWriter<LoadEntityForClientMessage>,
 ) {
-    // Wrap the events in this, so we only need one channel.
-    enum ChannelEvent {
-        UnloadEntity(UnloadEntityForClientEvent),
-        LoadEntity(LoadEntityForClientEvent),
+    // Wrap the messages in this, so we only need one channel.
+    enum ChannelMessage {
+        UnloadEntity(UnloadEntityForClientMessage),
+        LoadEntity(LoadEntityForClientMessage),
     }
 
     let (tx, rx) = std::sync::mpsc::channel();
@@ -1025,8 +1025,8 @@ pub(crate) fn update_view_and_layers(
                             for entity in layer.entities_at(pos) {
                                 if self_entity != entity {
                                     if let Ok(id) = entity_ids.get(entity) {
-                                        tx.send(ChannelEvent::UnloadEntity(
-                                            UnloadEntityForClientEvent {
+                                        tx.send(ChannelMessage::UnloadEntity(
+                                            UnloadEntityForClientMessage {
                                                 client: self_entity,
                                                 entity_unloaded: entity,
                                             },
@@ -1050,8 +1050,8 @@ pub(crate) fn update_view_and_layers(
                             for entity in layer.entities_at(pos) {
                                 if self_entity != entity {
                                     if let Ok((init, pos)) = entity_init.get(entity) {
-                                        tx.send(ChannelEvent::LoadEntity(
-                                            LoadEntityForClientEvent {
+                                        tx.send(ChannelMessage::LoadEntity(
+                                            LoadEntityForClientMessage {
                                                 client: self_entity,
                                                 entity_loaded: entity,
                                             },
@@ -1078,8 +1078,8 @@ pub(crate) fn update_view_and_layers(
                                 for entity in layer.entities_at(pos) {
                                     if self_entity != entity {
                                         if let Ok(id) = entity_ids.get(entity) {
-                                            tx.send(ChannelEvent::UnloadEntity(
-                                                UnloadEntityForClientEvent {
+                                            tx.send(ChannelMessage::UnloadEntity(
+                                                UnloadEntityForClientMessage {
                                                     client: self_entity,
                                                     entity_unloaded: entity,
                                                 },
@@ -1106,8 +1106,8 @@ pub(crate) fn update_view_and_layers(
                                 for entity in layer.entities_at(pos) {
                                     if self_entity != entity {
                                         if let Ok((init, pos)) = entity_init.get(entity) {
-                                            tx.send(ChannelEvent::LoadEntity(
-                                                LoadEntityForClientEvent {
+                                            tx.send(ChannelMessage::LoadEntity(
+                                                LoadEntityForClientMessage {
                                                     client: self_entity,
                                                     entity_loaded: entity,
                                                 },
@@ -1156,8 +1156,8 @@ pub(crate) fn update_view_and_layers(
                                 for entity in layer.entities_at(pos) {
                                     if self_entity != entity {
                                         if let Ok(id) = entity_ids.get(entity) {
-                                            tx.send(ChannelEvent::UnloadEntity(
-                                                UnloadEntityForClientEvent {
+                                            tx.send(ChannelMessage::UnloadEntity(
+                                                UnloadEntityForClientMessage {
                                                     client: self_entity,
                                                     entity_unloaded: entity,
                                                 },
@@ -1179,8 +1179,8 @@ pub(crate) fn update_view_and_layers(
                                 for entity in layer.entities_at(pos) {
                                     if self_entity != entity {
                                         if let Ok((init, pos)) = entity_init.get(entity) {
-                                            tx.send(ChannelEvent::LoadEntity(
-                                                LoadEntityForClientEvent {
+                                            tx.send(ChannelMessage::LoadEntity(
+                                                LoadEntityForClientMessage {
                                                     client: self_entity,
                                                     entity_loaded: entity,
                                                 },
@@ -1209,14 +1209,14 @@ pub(crate) fn update_view_and_layers(
         },
     );
 
-    // Send the events.
-    for event in rx.try_iter() {
-        match event {
-            ChannelEvent::UnloadEntity(event) => {
-                unload_entity_writer.write(event);
+    // Send the messages.
+    for message in rx.try_iter() {
+        match message {
+            ChannelMessage::UnloadEntity(message) => {
+                unload_entity_writer.write(message);
             }
-            ChannelEvent::LoadEntity(event) => {
-                load_entity_writer.write(event);
+            ChannelMessage::LoadEntity(message) => {
+                load_entity_writer.write(message);
             }
         };
     }

--- a/crates/chunkedge_server/src/client_command.rs
+++ b/crates/chunkedge_server/src/client_command.rs
@@ -5,22 +5,22 @@ use chunkedge_entity::{entity, Pose};
 pub use chunkedge_protocol::packets::play::player_command_c2s::PlayerCommand;
 use chunkedge_protocol::packets::play::PlayerCommandC2s;
 
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct ClientCommandPlugin;
 
 impl Plugin for ClientCommandPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<SprintEvent>()
-            .add_message::<SneakEvent>()
-            .add_message::<JumpWithHorseEvent>()
-            .add_message::<LeaveBedEvent>()
+        app.add_message::<SprintMessage>()
+            .add_message::<SneakMessage>()
+            .add_message::<JumpWithHorseMessage>()
+            .add_message::<LeaveBedMessage>()
             .add_systems(EventLoopPreUpdate, handle_client_command);
     }
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct SprintEvent {
+pub struct SprintMessage {
     pub client: Entity,
     pub state: SprintState,
 }
@@ -32,7 +32,7 @@ pub enum SprintState {
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct SneakEvent {
+pub struct SneakMessage {
     pub client: Entity,
     pub state: SneakState,
 }
@@ -44,7 +44,7 @@ pub enum SneakState {
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct JumpWithHorseEvent {
+pub struct JumpWithHorseMessage {
     pub client: Entity,
     pub state: JumpWithHorseState,
 }
@@ -59,17 +59,17 @@ pub enum JumpWithHorseState {
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct LeaveBedEvent {
+pub struct LeaveBedMessage {
     pub client: Entity,
 }
 
 fn handle_client_command(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(&mut entity::Pose, &mut Flags)>,
-    mut sprinting_events: MessageWriter<SprintEvent>,
-    mut sneaking_events: MessageWriter<SneakEvent>,
-    mut jump_with_horse_events: MessageWriter<JumpWithHorseEvent>,
-    mut leave_bed_events: MessageWriter<LeaveBedEvent>,
+    mut sprinting_messages: MessageWriter<SprintMessage>,
+    mut sneaking_messages: MessageWriter<SneakMessage>,
+    mut jump_with_horse_messages: MessageWriter<JumpWithHorseMessage>,
+    mut leave_bed_messages: MessageWriter<LeaveBedMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<PlayerCommandC2s>() {
@@ -80,7 +80,7 @@ fn handle_client_command(
                         flags.set_sneaking(true);
                     }
 
-                    sneaking_events.write(SneakEvent {
+                    sneaking_messages.write(SneakMessage {
                         client: packet.client,
                         state: SneakState::Start,
                     });
@@ -91,13 +91,13 @@ fn handle_client_command(
                         flags.set_sneaking(false);
                     }
 
-                    sneaking_events.write(SneakEvent {
+                    sneaking_messages.write(SneakMessage {
                         client: packet.client,
                         state: SneakState::Stop,
                     });
                 }
                 PlayerCommand::LeaveBed => {
-                    leave_bed_events.write(LeaveBedEvent {
+                    leave_bed_messages.write(LeaveBedMessage {
                         client: packet.client,
                     });
                 }
@@ -106,7 +106,7 @@ fn handle_client_command(
                         flags.set_sprinting(true);
                     }
 
-                    sprinting_events.write(SprintEvent {
+                    sprinting_messages.write(SprintMessage {
                         client: packet.client,
                         state: SprintState::Start,
                     });
@@ -116,13 +116,13 @@ fn handle_client_command(
                         flags.set_sprinting(false);
                     }
 
-                    sprinting_events.write(SprintEvent {
+                    sprinting_messages.write(SprintMessage {
                         client: packet.client,
                         state: SprintState::Stop,
                     });
                 }
                 PlayerCommand::StartJumpWithHorse => {
-                    jump_with_horse_events.write(JumpWithHorseEvent {
+                    jump_with_horse_messages.write(JumpWithHorseMessage {
                         client: packet.client,
                         state: JumpWithHorseState::Start {
                             power: pkt.jump_boost.0 as u8,
@@ -130,7 +130,7 @@ fn handle_client_command(
                     });
                 }
                 PlayerCommand::StopJumpWithHorse => {
-                    jump_with_horse_events.write(JumpWithHorseEvent {
+                    jump_with_horse_messages.write(JumpWithHorseMessage {
                         client: packet.client,
                         state: JumpWithHorseState::Stop,
                     });

--- a/crates/chunkedge_server/src/client_settings.rs
+++ b/crates/chunkedge_server/src/client_settings.rs
@@ -6,7 +6,7 @@ use chunkedge_protocol::packets::play::client_information_c2s::ChatMode;
 use chunkedge_protocol::packets::play::ClientInformationC2s;
 
 use crate::client::ViewDistance;
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct ClientSettingsPlugin;
 
@@ -28,7 +28,7 @@ pub struct ClientSettings {
 }
 
 fn handle_client_settings(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(
         &mut ViewDistance,
         &mut ClientSettings,

--- a/crates/chunkedge_server/src/custom_payload.rs
+++ b/crates/chunkedge_server/src/custom_payload.rs
@@ -5,19 +5,19 @@ use chunkedge_protocol::packets::play::{CustomPayloadC2s, CustomPayloadS2c};
 use chunkedge_protocol::{Ident, WritePacket};
 
 use crate::client::Client;
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct CustomPayloadPlugin;
 
 impl Plugin for CustomPayloadPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<CustomPayloadEvent>()
+        app.add_message::<CustomPayloadMessage>()
             .add_systems(EventLoopPreUpdate, handle_custom_payload);
     }
 }
 
 #[derive(Message, Clone, Debug)]
-pub struct CustomPayloadEvent {
+pub struct CustomPayloadMessage {
     pub client: Entity,
     pub channel: Ident<String>,
     pub data: Box<[u8]>,
@@ -33,12 +33,12 @@ impl Client {
 }
 
 fn handle_custom_payload(
-    mut packets: MessageReader<PacketEvent>,
-    mut events: MessageWriter<CustomPayloadEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut messages: MessageWriter<CustomPayloadMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<CustomPayloadC2s>() {
-            events.write(CustomPayloadEvent {
+            messages.write(CustomPayloadMessage {
                 client: packet.client,
                 channel: pkt.channel.into(),
                 data: pkt.data.0 .0.into(),

--- a/crates/chunkedge_server/src/event_loop.rs
+++ b/crates/chunkedge_server/src/event_loop.rs
@@ -113,12 +113,12 @@ fn run_event_loop(
 ) {
     debug_assert!(check_again.is_empty());
 
-    let (mut clients, mut event_writer, mut commands) = state.get_mut(world);
+    let (mut clients, mut message_writer, mut commands) = state.get_mut(world);
 
     for (entity, mut client) in &mut clients {
         match client.connection_mut().try_recv() {
             Ok(Some(pkt)) => {
-                event_writer.write(PacketMessage {
+                message_writer.write(PacketMessage {
                     client: entity,
                     timestamp: pkt.timestamp,
                     id: pkt.id,
@@ -144,7 +144,7 @@ fn run_event_loop(
     run_event_loop_schedules(world);
 
     while !check_again.is_empty() {
-        let (mut clients, mut event_writer, mut commands) = state.get_mut(world);
+        let (mut clients, mut message_writer, mut commands) = state.get_mut(world);
 
         check_again.retain_mut(|(entity, remaining)| {
             debug_assert!(*remaining > 0);
@@ -152,7 +152,7 @@ fn run_event_loop(
             if let Ok((_, mut client)) = clients.get_mut(*entity) {
                 match client.connection_mut().try_recv() {
                     Ok(Some(pkt)) => {
-                        event_writer.write(PacketMessage {
+                        message_writer.write(PacketMessage {
                             client: *entity,
                             timestamp: pkt.timestamp,
                             id: pkt.id,

--- a/crates/chunkedge_server/src/event_loop.rs
+++ b/crates/chunkedge_server/src/event_loop.rs
@@ -16,7 +16,7 @@ pub struct EventLoopPlugin;
 
 impl Plugin for EventLoopPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<PacketEvent>()
+        app.add_message::<PacketMessage>()
             .add_schedule(Schedule::new(RunEventLoop))
             .add_schedule(Schedule::new(EventLoopPreUpdate))
             .add_schedule(Schedule::new(EventLoopUpdate))
@@ -46,7 +46,7 @@ pub struct EventLoopUpdate;
 pub struct EventLoopPostUpdate;
 
 #[derive(Message, Clone, Debug)]
-pub struct PacketEvent {
+pub struct PacketMessage {
     /// The client this packet originated from.
     pub client: Entity,
     /// The moment in time this packet arrived.
@@ -57,7 +57,7 @@ pub struct PacketEvent {
     pub data: Bytes,
 }
 
-impl PacketEvent {
+impl PacketMessage {
     /// Attempts to decode this packet as the packet `P`.
     ///
     /// If the packet ID is mismatched or an error occurs, `None` is returned.
@@ -106,7 +106,7 @@ fn run_event_loop(
     world: &mut World,
     state: &mut SystemState<(
         Query<(Entity, &mut Client)>,
-        MessageWriter<PacketEvent>,
+        MessageWriter<PacketMessage>,
         Commands,
     )>,
     mut check_again: Local<Vec<(Entity, usize)>>,
@@ -118,7 +118,7 @@ fn run_event_loop(
     for (entity, mut client) in &mut clients {
         match client.connection_mut().try_recv() {
             Ok(Some(pkt)) => {
-                event_writer.write(PacketEvent {
+                event_writer.write(PacketMessage {
                     client: entity,
                     timestamp: pkt.timestamp,
                     id: pkt.id,
@@ -152,7 +152,7 @@ fn run_event_loop(
             if let Ok((_, mut client)) = clients.get_mut(*entity) {
                 match client.connection_mut().try_recv() {
                     Ok(Some(pkt)) => {
-                        event_writer.write(PacketEvent {
+                        event_writer.write(PacketMessage {
                             client: *entity,
                             timestamp: pkt.timestamp,
                             id: pkt.id,

--- a/crates/chunkedge_server/src/hand_swing.rs
+++ b/crates/chunkedge_server/src/hand_swing.rs
@@ -4,27 +4,27 @@ use chunkedge_entity::{EntityAnimation, EntityAnimations};
 use chunkedge_protocol::packets::play::SwingC2s;
 use chunkedge_protocol::Hand;
 
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct HandSwingPlugin;
 
 impl Plugin for HandSwingPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<HandSwingEvent>()
+        app.add_message::<HandSwingMessage>()
             .add_systems(EventLoopPreUpdate, handle_hand_swing);
     }
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct HandSwingEvent {
+pub struct HandSwingMessage {
     pub client: Entity,
     pub hand: Hand,
 }
 
 fn handle_hand_swing(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<&mut EntityAnimations>,
-    mut events: MessageWriter<HandSwingEvent>,
+    mut messages: MessageWriter<HandSwingMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<SwingC2s>() {
@@ -35,7 +35,7 @@ fn handle_hand_swing(
                 });
             }
 
-            events.write(HandSwingEvent {
+            messages.write(HandSwingMessage {
                 client: packet.client,
                 hand: pkt.hand,
             });

--- a/crates/chunkedge_server/src/interact_block.rs
+++ b/crates/chunkedge_server/src/interact_block.rs
@@ -5,19 +5,19 @@ use chunkedge_protocol::packets::play::UseItemOnC2s;
 use chunkedge_protocol::{BlockPos, Direction, Hand};
 
 use crate::action::ActionSequence;
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct InteractBlockPlugin;
 
 impl Plugin for InteractBlockPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<InteractBlockEvent>()
+        app.add_message::<InteractBlockMessage>()
             .add_systems(EventLoopPreUpdate, handle_interact_block);
     }
 }
 
 #[derive(Message, Copy, Clone, Debug)]
-pub struct InteractBlockEvent {
+pub struct InteractBlockMessage {
     pub client: Entity,
     /// The hand that was used
     pub hand: Hand,
@@ -34,9 +34,9 @@ pub struct InteractBlockEvent {
 }
 
 fn handle_interact_block(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<&mut ActionSequence>,
-    mut events: MessageWriter<InteractBlockEvent>,
+    mut messages: MessageWriter<InteractBlockMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<UseItemOnC2s>() {
@@ -46,7 +46,7 @@ fn handle_interact_block(
 
             // TODO: check that the block interaction is valid.
 
-            events.write(InteractBlockEvent {
+            messages.write(InteractBlockMessage {
                 client: packet.client,
                 hand: pkt.hand,
                 position: pkt.position,

--- a/crates/chunkedge_server/src/interact_entity.rs
+++ b/crates/chunkedge_server/src/interact_entity.rs
@@ -4,19 +4,19 @@ use chunkedge_entity::EntityManager;
 pub use chunkedge_protocol::packets::play::interact_c2s::EntityInteraction;
 use chunkedge_protocol::packets::play::InteractC2s;
 
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct InteractEntityPlugin;
 
 impl Plugin for InteractEntityPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<InteractEntityEvent>()
+        app.add_message::<InteractEntityMessage>()
             .add_systems(EventLoopPreUpdate, handle_interact_entity);
     }
 }
 
 #[derive(Message, Copy, Clone, Debug)]
-pub struct InteractEntityEvent {
+pub struct InteractEntityMessage {
     pub client: Entity,
     /// The entity being interacted with.
     pub entity: Entity,
@@ -27,9 +27,9 @@ pub struct InteractEntityEvent {
 }
 
 fn handle_interact_entity(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     entities: Res<EntityManager>,
-    mut events: MessageWriter<InteractEntityEvent>,
+    mut messages: MessageWriter<InteractEntityMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<InteractC2s>() {
@@ -38,7 +38,7 @@ fn handle_interact_entity(
             // within some configurable tolerance level.
 
             if let Some(entity) = entities.get_by_id(pkt.entity_id.0) {
-                events.write(InteractEntityEvent {
+                messages.write(InteractEntityMessage {
                     client: packet.client,
                     entity,
                     sneaking: pkt.sneaking,

--- a/crates/chunkedge_server/src/interact_item.rs
+++ b/crates/chunkedge_server/src/interact_item.rs
@@ -4,28 +4,28 @@ use chunkedge_protocol::packets::play::UseItemC2s;
 use chunkedge_protocol::Hand;
 
 use crate::action::ActionSequence;
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct InteractItemPlugin;
 
 impl Plugin for InteractItemPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<InteractItemEvent>()
+        app.add_message::<InteractItemMessage>()
             .add_systems(EventLoopPreUpdate, handle_player_interact_item);
     }
 }
 
 #[derive(Message, Copy, Clone, Debug)]
-pub struct InteractItemEvent {
+pub struct InteractItemMessage {
     pub client: Entity,
     pub hand: Hand,
     pub sequence: i32,
 }
 
 fn handle_player_interact_item(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<&mut ActionSequence>,
-    mut events: MessageWriter<InteractItemEvent>,
+    mut messages: MessageWriter<InteractItemMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<UseItemC2s>() {
@@ -33,7 +33,7 @@ fn handle_player_interact_item(
                 action_seq.update(pkt.sequence.0);
             }
 
-            events.write(InteractItemEvent {
+            messages.write(InteractItemMessage {
                 client: packet.client,
                 hand: pkt.hand,
                 sequence: pkt.sequence.0,

--- a/crates/chunkedge_server/src/keepalive.rs
+++ b/crates/chunkedge_server/src/keepalive.rs
@@ -8,7 +8,7 @@ use derive_more::Deref;
 use tracing::warn;
 
 use crate::client::{Client, UpdateClientsSet};
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct KeepalivePlugin;
 
@@ -92,7 +92,7 @@ fn send_keepalive(
 }
 
 fn handle_keepalive_response(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(Entity, &mut KeepaliveState, &mut Ping)>,
     mut commands: Commands,
 ) {

--- a/crates/chunkedge_server/src/message.rs
+++ b/crates/chunkedge_server/src/message.rs
@@ -13,7 +13,7 @@ pub struct MessagePlugin;
 
 impl Plugin for MessagePlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<ChatMessageMessage>()
+        app.add_message::<ChatReceivedMessage>()
             .add_systems(EventLoopPreUpdate, handle_chat_message);
     }
 }
@@ -41,20 +41,24 @@ impl<T: WritePacket> SendMessage for T {
     }
 }
 
+/// Message emitted when a client sends a chat message to the server.
 #[derive(Message, Clone, Debug)]
-pub struct ChatMessageMessage {
+pub struct ChatReceivedMessage {
+    /// The client that sent the chat message.
     pub client: Entity,
+    /// The raw chat message text sent.
     pub message: Box<str>,
+    /// The client-provided timestamp.
     pub timestamp: u64,
 }
 
 pub fn handle_chat_message(
     mut packets: MessageReader<PacketMessage>,
-    mut messages: MessageWriter<ChatMessageMessage>,
+    mut messages: MessageWriter<ChatReceivedMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<ChatC2s>() {
-            messages.write(ChatMessageMessage {
+            messages.write(ChatReceivedMessage {
                 client: packet.client,
                 message: pkt.message.0.into(),
                 timestamp: pkt.timestamp,

--- a/crates/chunkedge_server/src/message.rs
+++ b/crates/chunkedge_server/src/message.rs
@@ -7,13 +7,13 @@ use chunkedge_protocol::packets::play::{ChatC2s, SystemChatS2c};
 use chunkedge_protocol::text::IntoText;
 use chunkedge_protocol::IntoTextComponent;
 
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct MessagePlugin;
 
 impl Plugin for MessagePlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<ChatMessageEvent>()
+        app.add_message::<ChatMessageMessage>()
             .add_systems(EventLoopPreUpdate, handle_chat_message);
     }
 }
@@ -42,19 +42,19 @@ impl<T: WritePacket> SendMessage for T {
 }
 
 #[derive(Message, Clone, Debug)]
-pub struct ChatMessageEvent {
+pub struct ChatMessageMessage {
     pub client: Entity,
     pub message: Box<str>,
     pub timestamp: u64,
 }
 
 pub fn handle_chat_message(
-    mut packets: MessageReader<PacketEvent>,
-    mut events: MessageWriter<ChatMessageEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut messages: MessageWriter<ChatMessageMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<ChatC2s>() {
-            events.write(ChatMessageEvent {
+            messages.write(ChatMessageMessage {
                 client: packet.client,
                 message: pkt.message.0.into(),
                 timestamp: pkt.timestamp,

--- a/crates/chunkedge_server/src/movement.rs
+++ b/crates/chunkedge_server/src/movement.rs
@@ -7,7 +7,7 @@ use chunkedge_protocol::packets::play::{
     MoveVehicleC2s,
 };
 
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 use crate::teleport::TeleportState;
 
 pub struct MovementPlugin;
@@ -15,7 +15,7 @@ pub struct MovementPlugin;
 impl Plugin for MovementPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<MovementSettings>()
-            .add_message::<MovementEvent>()
+            .add_message::<MovementMessage>()
             .add_systems(EventLoopPreUpdate, handle_client_movement);
     }
 }
@@ -24,9 +24,9 @@ impl Plugin for MovementPlugin {
 #[derive(Resource, Default)]
 pub struct MovementSettings; // TODO
 
-/// Event sent when a client successfully moves.
+/// Message sent when a client successfully moves.
 #[derive(Message, Clone, Debug)]
-pub struct MovementEvent {
+pub struct MovementMessage {
     pub client: Entity,
     pub position: DVec3,
     pub old_position: DVec3,
@@ -37,7 +37,7 @@ pub struct MovementEvent {
 }
 
 fn handle_client_movement(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<(
         &mut Position,
         &mut Look,
@@ -45,14 +45,14 @@ fn handle_client_movement(
         &mut OnGround,
         &mut TeleportState,
     )>,
-    mut movement_events: MessageWriter<MovementEvent>,
+    mut movement_messages: MessageWriter<MovementMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<MovePlayerPosC2s>() {
             if let Ok((pos, look, head_yaw, on_ground, teleport_state)) =
                 clients.get_mut(packet.client)
             {
-                let mov = MovementEvent {
+                let mov = MovementMessage {
                     client: packet.client,
                     position: pkt.position,
                     old_position: pos.0,
@@ -69,14 +69,14 @@ fn handle_client_movement(
                     head_yaw,
                     on_ground,
                     teleport_state,
-                    &mut movement_events,
+                    &mut movement_messages,
                 );
             }
         } else if let Some(pkt) = packet.decode::<MovePlayerPosRotC2s>() {
             if let Ok((pos, look, head_yaw, on_ground, teleport_state)) =
                 clients.get_mut(packet.client)
             {
-                let mov = MovementEvent {
+                let mov = MovementMessage {
                     client: packet.client,
                     position: pkt.position,
                     old_position: pos.0,
@@ -96,14 +96,14 @@ fn handle_client_movement(
                     head_yaw,
                     on_ground,
                     teleport_state,
-                    &mut movement_events,
+                    &mut movement_messages,
                 );
             }
         } else if let Some(pkt) = packet.decode::<MovePlayerRotC2s>() {
             if let Ok((pos, look, head_yaw, on_ground, teleport_state)) =
                 clients.get_mut(packet.client)
             {
-                let mov = MovementEvent {
+                let mov = MovementMessage {
                     client: packet.client,
                     position: pos.0,
                     old_position: pos.0,
@@ -123,14 +123,14 @@ fn handle_client_movement(
                     head_yaw,
                     on_ground,
                     teleport_state,
-                    &mut movement_events,
+                    &mut movement_messages,
                 );
             }
         } else if let Some(pkt) = packet.decode::<MovePlayerStatusOnlyC2s>() {
             if let Ok((pos, look, head_yaw, on_ground, teleport_state)) =
                 clients.get_mut(packet.client)
             {
-                let mov = MovementEvent {
+                let mov = MovementMessage {
                     client: packet.client,
                     position: pos.0,
                     old_position: pos.0,
@@ -147,14 +147,14 @@ fn handle_client_movement(
                     head_yaw,
                     on_ground,
                     teleport_state,
-                    &mut movement_events,
+                    &mut movement_messages,
                 );
             }
         } else if let Some(pkt) = packet.decode::<MoveVehicleC2s>() {
             if let Ok((pos, look, head_yaw, on_ground, teleport_state)) =
                 clients.get_mut(packet.client)
             {
-                let mov = MovementEvent {
+                let mov = MovementMessage {
                     client: packet.client,
                     position: pkt.position,
                     old_position: pos.0,
@@ -174,7 +174,7 @@ fn handle_client_movement(
                     head_yaw,
                     on_ground,
                     teleport_state,
-                    &mut movement_events,
+                    &mut movement_messages,
                 );
             }
         }
@@ -182,13 +182,13 @@ fn handle_client_movement(
 }
 
 fn handle(
-    mov: MovementEvent,
+    mov: MovementMessage,
     mut pos: Mut<Position>,
     mut look: Mut<Look>,
     mut head_yaw: Mut<HeadYaw>,
     mut on_ground: Mut<OnGround>,
     mut teleport_state: Mut<TeleportState>,
-    movement_events: &mut MessageWriter<MovementEvent>,
+    movement_messages: &mut MessageWriter<MovementMessage>,
 ) {
     if teleport_state.pending_teleports() != 0 {
         return;
@@ -204,5 +204,5 @@ fn handle(
     head_yaw.set_if_neq(HeadYaw(mov.look.yaw));
     on_ground.set_if_neq(OnGround(mov.on_ground));
 
-    movement_events.write(mov);
+    movement_messages.write(mov);
 }

--- a/crates/chunkedge_server/src/resource_pack.rs
+++ b/crates/chunkedge_server/src/resource_pack.rs
@@ -6,19 +6,19 @@ use chunkedge_protocol::{IntoTextComponent, WritePacket};
 use uuid::Uuid;
 
 use crate::client::Client;
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct ResourcePackPlugin;
 
 impl Plugin for ResourcePackPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<ResourcePackStatusEvent>()
+        app.add_message::<ResourcePackStatusMessage>()
             .add_systems(EventLoopPreUpdate, handle_resource_pack_status);
     }
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct ResourcePackStatusEvent {
+pub struct ResourcePackStatusMessage {
     pub client: Entity,
     pub status: ResourcePackC2s,
 }
@@ -86,12 +86,12 @@ impl Client {
 }
 
 fn handle_resource_pack_status(
-    mut packets: MessageReader<PacketEvent>,
-    mut events: MessageWriter<ResourcePackStatusEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut messages: MessageWriter<ResourcePackStatusMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<ResourcePackC2s>() {
-            events.write(ResourcePackStatusEvent {
+            messages.write(ResourcePackStatusMessage {
                 client: packet.client,
                 status: pkt,
             });

--- a/crates/chunkedge_server/src/status.rs
+++ b/crates/chunkedge_server/src/status.rs
@@ -2,43 +2,43 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use chunkedge_protocol::packets::play::ClientCommandC2s;
 
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 
 pub struct StatusPlugin;
 
 impl Plugin for StatusPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<RequestRespawnEvent>()
-            .add_message::<RequestStatsEvent>()
+        app.add_message::<RequestRespawnMessage>()
+            .add_message::<RequestStatsMessage>()
             .add_systems(EventLoopPreUpdate, handle_status);
     }
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct RequestRespawnEvent {
+pub struct RequestRespawnMessage {
     pub client: Entity,
 }
 
 #[derive(Message, Copy, Clone, PartialEq, Eq, Debug)]
-pub struct RequestStatsEvent {
+pub struct RequestStatsMessage {
     pub client: Entity,
 }
 
 fn handle_status(
-    mut packets: MessageReader<PacketEvent>,
-    mut respawn_events: MessageWriter<RequestRespawnEvent>,
-    mut request_stats_events: MessageWriter<RequestStatsEvent>,
+    mut packets: MessageReader<PacketMessage>,
+    mut respawn_messages: MessageWriter<RequestRespawnMessage>,
+    mut request_stats_messages: MessageWriter<RequestStatsMessage>,
 ) {
     for packet in packets.read() {
         if let Some(pkt) = packet.decode::<ClientCommandC2s>() {
             match pkt {
                 ClientCommandC2s::PerformRespawn => {
-                    respawn_events.write(RequestRespawnEvent {
+                    respawn_messages.write(RequestRespawnMessage {
                         client: packet.client,
                     });
                 }
                 ClientCommandC2s::RequestStats => {
-                    request_stats_events.write(RequestStatsEvent {
+                    request_stats_messages.write(RequestStatsMessage {
                         client: packet.client,
                     });
                 }

--- a/crates/chunkedge_server/src/status_effect.rs
+++ b/crates/chunkedge_server/src/status_effect.rs
@@ -24,7 +24,7 @@ pub struct StatusEffectAdded {
 
 /// Message for when a status effect is removed from an entity.
 #[derive(Message, Clone, PartialEq, Eq, Debug)]
-pub struct StatusEffectRemoved {
+pub struct StatusEffectRemovedMessage {
     pub entity: Entity,
     pub status_effect: ActiveStatusEffect,
 }
@@ -34,7 +34,7 @@ pub struct StatusEffectPlugin;
 impl Plugin for StatusEffectPlugin {
     fn build(&self, app: &mut App) {
         app.add_message::<StatusEffectAdded>()
-            .add_message::<StatusEffectRemoved>()
+            .add_message::<StatusEffectRemovedMessage>()
             .add_systems(
                 EventLoopPostUpdate,
                 (
@@ -82,7 +82,7 @@ struct StatusEffectQuery {
 fn add_status_effects(
     mut query: Query<StatusEffectQuery>,
     mut add_messages: MessageWriter<StatusEffectAdded>,
-    mut remove_messages: MessageWriter<StatusEffectRemoved>,
+    mut remove_messages: MessageWriter<StatusEffectRemovedMessage>,
 ) {
     for mut query in &mut query {
         let updated = query.active_effects.apply_changes();
@@ -100,7 +100,7 @@ fn add_status_effects(
                     status_effect,
                 });
             } else if let Some(prev) = prev {
-                remove_messages.write(StatusEffectRemoved {
+                remove_messages.write(StatusEffectRemovedMessage {
                     entity: query.entity,
                     status_effect: prev,
                 });

--- a/crates/chunkedge_server/src/status_effect.rs
+++ b/crates/chunkedge_server/src/status_effect.rs
@@ -14,7 +14,7 @@ use chunkedge_protocol::{VarInt, WritePacket};
 use crate::client::Client;
 use crate::EventLoopPostUpdate;
 
-/// Event for when a status effect is added to an entity or the amplifier or
+/// Message for when a status effect is added to an entity or the amplifier or
 /// duration of an existing status effect is changed.
 #[derive(Message, Clone, PartialEq, Eq, Debug)]
 pub struct StatusEffectAdded {
@@ -22,7 +22,7 @@ pub struct StatusEffectAdded {
     pub status_effect: StatusEffect,
 }
 
-/// Event for when a status effect is removed from an entity.
+/// Message for when a status effect is removed from an entity.
 #[derive(Message, Clone, PartialEq, Eq, Debug)]
 pub struct StatusEffectRemoved {
     pub entity: Entity,
@@ -81,8 +81,8 @@ struct StatusEffectQuery {
 
 fn add_status_effects(
     mut query: Query<StatusEffectQuery>,
-    mut add_events: MessageWriter<StatusEffectAdded>,
-    mut remove_events: MessageWriter<StatusEffectRemoved>,
+    mut add_messages: MessageWriter<StatusEffectAdded>,
+    mut remove_messages: MessageWriter<StatusEffectRemoved>,
 ) {
     for mut query in &mut query {
         let updated = query.active_effects.apply_changes();
@@ -95,12 +95,12 @@ fn add_status_effects(
 
         for (status_effect, prev) in updated {
             if query.active_effects.has_effect(status_effect) {
-                add_events.write(StatusEffectAdded {
+                add_messages.write(StatusEffectAdded {
                     entity: query.entity,
                     status_effect,
                 });
             } else if let Some(prev) = prev {
-                remove_events.write(StatusEffectRemoved {
+                remove_messages.write(StatusEffectRemoved {
                     entity: query.entity,
                     status_effect: prev,
                 });

--- a/crates/chunkedge_server/src/status_effect.rs
+++ b/crates/chunkedge_server/src/status_effect.rs
@@ -17,7 +17,7 @@ use crate::EventLoopPostUpdate;
 /// Message for when a status effect is added to an entity or the amplifier or
 /// duration of an existing status effect is changed.
 #[derive(Message, Clone, PartialEq, Eq, Debug)]
-pub struct StatusEffectAdded {
+pub struct StatusEffectAddedMessage {
     pub entity: Entity,
     pub status_effect: StatusEffect,
 }
@@ -33,7 +33,7 @@ pub struct StatusEffectPlugin;
 
 impl Plugin for StatusEffectPlugin {
     fn build(&self, app: &mut App) {
-        app.add_message::<StatusEffectAdded>()
+        app.add_message::<StatusEffectAddedMessage>()
             .add_message::<StatusEffectRemovedMessage>()
             .add_systems(
                 EventLoopPostUpdate,
@@ -81,7 +81,7 @@ struct StatusEffectQuery {
 
 fn add_status_effects(
     mut query: Query<StatusEffectQuery>,
-    mut add_messages: MessageWriter<StatusEffectAdded>,
+    mut add_messages: MessageWriter<StatusEffectAddedMessage>,
     mut remove_messages: MessageWriter<StatusEffectRemovedMessage>,
 ) {
     for mut query in &mut query {
@@ -95,7 +95,7 @@ fn add_status_effects(
 
         for (status_effect, prev) in updated {
             if query.active_effects.has_effect(status_effect) {
-                add_messages.write(StatusEffectAdded {
+                add_messages.write(StatusEffectAddedMessage {
                     entity: query.entity,
                     status_effect,
                 });

--- a/crates/chunkedge_server/src/teleport.rs
+++ b/crates/chunkedge_server/src/teleport.rs
@@ -8,7 +8,7 @@ use chunkedge_protocol::WritePacket;
 use tracing::warn;
 
 use crate::client::{update_view_and_layers, Client, UpdateClientsSet};
-use crate::event_loop::{EventLoopPreUpdate, PacketEvent};
+use crate::event_loop::{EventLoopPreUpdate, PacketMessage};
 use crate::spawn::update_respawn_position;
 
 pub struct TeleportPlugin;
@@ -116,7 +116,7 @@ fn teleport(
 }
 
 fn handle_teleport_confirmations(
-    mut packets: MessageReader<PacketEvent>,
+    mut packets: MessageReader<PacketMessage>,
     mut clients: Query<&mut TeleportState>,
     mut commands: Commands,
 ) {

--- a/crates/chunkedge_text/src/into_text.rs
+++ b/crates/chunkedge_text/src/into_text.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use super::{ClickEvent, Color, Font, HoverEvent, Text};
+use super::{ClickMessage, Color, Font, HoverEvent, Text};
 
 /// Trait for any data that can be converted to a [`Text`] object.
 ///
@@ -171,14 +171,14 @@ pub trait IntoText<'a>: Sized {
     /// On click, opens the given URL. Has to be `http` or `https` protocol.
     fn on_click_open_url(self, url: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickEvent::OpenUrl { url: url.into() });
+        value.click_event = Some(ClickMessage::OpenUrl { url: url.into() });
         value
     }
     /// On click, sends a command. Doesn't actually have to be a command, can be
     /// a simple chat message.
     fn on_click_run_command(self, command: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickEvent::RunCommand {
+        value.click_event = Some(ClickMessage::RunCommand {
             command: command.into(),
         });
         value
@@ -186,7 +186,7 @@ pub trait IntoText<'a>: Sized {
     /// On click, copies the given text to the chat box.
     fn on_click_suggest_command(self, command: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickEvent::SuggestCommand {
+        value.click_event = Some(ClickMessage::SuggestCommand {
             command: command.into(),
         });
         value
@@ -195,13 +195,13 @@ pub trait IntoText<'a>: Sized {
     /// Indexing starts at `1`.
     fn on_click_change_page(self, page: impl Into<i32>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickEvent::ChangePage { page: page.into() });
+        value.click_event = Some(ClickMessage::ChangePage { page: page.into() });
         value
     }
     /// On click, copies the given text to clipboard.
     fn on_click_copy_to_clipboard(self, text: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickEvent::CopyToClipboard { value: text.into() });
+        value.click_event = Some(ClickMessage::CopyToClipboard { value: text.into() });
         value
     }
     /// Clears the `click_event` property of the text. Property of the parent

--- a/crates/chunkedge_text/src/into_text.rs
+++ b/crates/chunkedge_text/src/into_text.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use super::{ClickMessage, Color, Font, HoverEvent, Text};
+use super::{ClickEvent, Color, Font, HoverEvent, Text};
 
 /// Trait for any data that can be converted to a [`Text`] object.
 ///
@@ -171,14 +171,14 @@ pub trait IntoText<'a>: Sized {
     /// On click, opens the given URL. Has to be `http` or `https` protocol.
     fn on_click_open_url(self, url: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickMessage::OpenUrl { url: url.into() });
+        value.click_event = Some(ClickEvent::OpenUrl { url: url.into() });
         value
     }
     /// On click, sends a command. Doesn't actually have to be a command, can be
     /// a simple chat message.
     fn on_click_run_command(self, command: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickMessage::RunCommand {
+        value.click_event = Some(ClickEvent::RunCommand {
             command: command.into(),
         });
         value
@@ -186,7 +186,7 @@ pub trait IntoText<'a>: Sized {
     /// On click, copies the given text to the chat box.
     fn on_click_suggest_command(self, command: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickMessage::SuggestCommand {
+        value.click_event = Some(ClickEvent::SuggestCommand {
             command: command.into(),
         });
         value
@@ -195,13 +195,13 @@ pub trait IntoText<'a>: Sized {
     /// Indexing starts at `1`.
     fn on_click_change_page(self, page: impl Into<i32>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickMessage::ChangePage { page: page.into() });
+        value.click_event = Some(ClickEvent::ChangePage { page: page.into() });
         value
     }
     /// On click, copies the given text to clipboard.
     fn on_click_copy_to_clipboard(self, text: impl Into<Cow<'static, str>>) -> Text {
         let mut value = self.into_text();
-        value.click_event = Some(ClickMessage::CopyToClipboard { value: text.into() });
+        value.click_event = Some(ClickEvent::CopyToClipboard { value: text.into() });
         value
     }
     /// Clears the `click_event` property of the text. Property of the parent

--- a/crates/chunkedge_text/src/lib.rs
+++ b/crates/chunkedge_text/src/lib.rs
@@ -94,7 +94,7 @@ pub struct TextInner {
     pub insertion: Option<Cow<'static, str>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub click_event: Option<ClickMessage>,
+    pub click_event: Option<ClickEvent>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hover_event: Option<HoverEvent>,
@@ -201,7 +201,7 @@ pub struct ScoreboardValueContent {
 /// Action to take on click of the text.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
-pub enum ClickMessage {
+pub enum ClickEvent {
     /// Opens an URL. it must start with `http://` or `https://`.
     OpenUrl { url: Cow<'static, str> },
     /// Only usable by internal servers for security reasons.

--- a/crates/chunkedge_text/src/lib.rs
+++ b/crates/chunkedge_text/src/lib.rs
@@ -94,7 +94,7 @@ pub struct TextInner {
     pub insertion: Option<Cow<'static, str>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub click_event: Option<ClickEvent>,
+    pub click_event: Option<ClickMessage>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hover_event: Option<HoverEvent>,
@@ -201,7 +201,7 @@ pub struct ScoreboardValueContent {
 /// Action to take on click of the text.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
-pub enum ClickEvent {
+pub enum ClickMessage {
     /// Opens an URL. it must start with `http://` or `https://`.
     OpenUrl { url: Cow<'static, str> },
     /// Only usable by internal servers for security reasons.

--- a/examples/advancement.rs
+++ b/examples/advancement.rs
@@ -247,7 +247,7 @@ fn init_advancements(
 }
 
 fn sneak(
-    mut sneaking: MessageReader<SneakEvent>,
+    mut sneaking: MessageReader<SneakMessage>,
     mut client: Query<(&mut AdvancementClientUpdate, &mut RootCriteriaDone)>,
     root_criteria: Query<Entity, With<RootCriteria>>,
     client_uuid: Query<&UniqueId>,
@@ -282,7 +282,7 @@ fn sneak(
 }
 
 fn tab_change(
-    mut tab_change: MessageReader<AdvancementTabChangeEvent>,
+    mut tab_change: MessageReader<AdvancementTabChangeMessage>,
     mut client: Query<(&mut AdvancementClientUpdate, &mut TabChangeCount)>,
     root2_criteria: Query<Entity, With<Root2Criteria>>,
     root: Query<Entity, With<RootAdvancement>>,

--- a/examples/anvil_loading.rs
+++ b/examples/anvil_loading.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use chunkedge::abilities::{FlyingSpeed, FovModifier, PlayerAbilitiesFlags};
 use chunkedge::message::SendMessage;
 use chunkedge::prelude::*;
-use chunkedge_anvil::{AnvilLevel, ChunkLoadEvent, ChunkLoadStatus};
+use chunkedge_anvil::{AnvilLevel, ChunkLoadMessage, ChunkLoadStatus};
 use clap::Parser;
 
 const SPAWN_POS: DVec3 = DVec3::new(0.0, 256.0, 0.0);
@@ -114,32 +114,32 @@ fn init_clients(
 }
 
 fn handle_chunk_loads(
-    mut events: MessageReader<ChunkLoadEvent>,
+    mut messages: MessageReader<ChunkLoadMessage>,
     mut layers: Query<&mut ChunkLayer, With<AnvilLevel>>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for event in events.read() {
-        match &event.status {
+    for message in messages.read() {
+        match &message.status {
             ChunkLoadStatus::Success { .. } => {
                 // The chunk was inserted into the world. Nothing for us to do.
             }
             ChunkLoadStatus::Empty => {
                 // There's no chunk here so let's insert an empty chunk. If we were doing
                 // terrain generation we would prepare that here.
-                layer.insert_chunk(event.pos, UnloadedChunk::new());
+                layer.insert_chunk(message.pos, UnloadedChunk::new());
             }
             ChunkLoadStatus::Failed(e) => {
                 // Something went wrong.
                 let errmsg = format!(
                     "failed to load chunk at ({}, {}): {e:#}",
-                    event.pos.x, event.pos.z
+                    message.pos.x, message.pos.z
                 );
 
                 eprintln!("{errmsg}");
                 layer.send_chat_message(errmsg.color(Color::RED));
 
-                layer.insert_chunk(event.pos, UnloadedChunk::new());
+                layer.insert_chunk(message.pos, UnloadedChunk::new());
             }
         }
     }

--- a/examples/block_entities.rs
+++ b/examples/block_entities.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use chunkedge::interact_block::InteractBlockMessage;
-use chunkedge::message::ChatMessageMessage;
+use chunkedge::message::ChatReceivedMessage;
 use chunkedge::nbt::{compound, List};
 use chunkedge::prelude::*;
 
@@ -113,13 +113,13 @@ fn init_clients(
 
 fn event_handler(
     clients: Query<&Username>,
-    mut messages: MessageReader<ChatMessageMessage>,
+    mut messages: MessageReader<ChatReceivedMessage>,
     mut block_interacts: MessageReader<InteractBlockMessage>,
     mut layers: Query<&mut ChunkLayer>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for ChatMessageMessage {
+    for ChatReceivedMessage {
         client, message, ..
     } in messages.read()
     {

--- a/examples/block_entities.rs
+++ b/examples/block_entities.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
-use chunkedge::interact_block::InteractBlockEvent;
-use chunkedge::message::ChatMessageEvent;
+use chunkedge::interact_block::InteractBlockMessage;
+use chunkedge::message::ChatMessageMessage;
 use chunkedge::nbt::{compound, List};
 use chunkedge::prelude::*;
 
@@ -113,13 +113,13 @@ fn init_clients(
 
 fn event_handler(
     clients: Query<&Username>,
-    mut messages: MessageReader<ChatMessageEvent>,
-    mut block_interacts: MessageReader<InteractBlockEvent>,
+    mut messages: MessageReader<ChatMessageMessage>,
+    mut block_interacts: MessageReader<InteractBlockMessage>,
     mut layers: Query<&mut ChunkLayer>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for ChatMessageEvent {
+    for ChatMessageMessage {
         client, message, ..
     } in messages.read()
     {
@@ -140,7 +140,7 @@ fn event_handler(
         });
     }
 
-    for InteractBlockEvent {
+    for InteractBlockMessage {
         client,
         position,
         hand,

--- a/examples/boss_bar.rs
+++ b/examples/boss_bar.rs
@@ -6,7 +6,7 @@ use chunkedge_boss_bar::{
     BossBarTitle,
 };
 use chunkedge_server::entity::cow::CowEntityBundle;
-use chunkedge_server::message::ChatMessageMessage;
+use chunkedge_server::message::ChatReceivedMessage;
 use chunkedge_text::color::NamedColor;
 use rand::seq::IndexedRandom;
 
@@ -137,7 +137,7 @@ fn init_clients(
 }
 
 fn listen_messages(
-    mut message_messages: MessageReader<ChatMessageMessage>,
+    mut message_messages: MessageReader<ChatReceivedMessage>,
     mut boss_bars_query: Query<
         (
             &mut BossBarStyle,
@@ -158,7 +158,7 @@ fn listen_messages(
         entity_layer_id,
     ) = boss_bars_query.single_mut().unwrap();
 
-    for ChatMessageMessage {
+    for ChatReceivedMessage {
         client, message, ..
     } in message_messages.read()
     {

--- a/examples/boss_bar.rs
+++ b/examples/boss_bar.rs
@@ -6,7 +6,7 @@ use chunkedge_boss_bar::{
     BossBarTitle,
 };
 use chunkedge_server::entity::cow::CowEntityBundle;
-use chunkedge_server::message::ChatMessageEvent;
+use chunkedge_server::message::ChatMessageMessage;
 use chunkedge_text::color::NamedColor;
 use rand::seq::IndexedRandom;
 
@@ -137,7 +137,7 @@ fn init_clients(
 }
 
 fn listen_messages(
-    mut message_events: MessageReader<ChatMessageEvent>,
+    mut message_messages: MessageReader<ChatMessageMessage>,
     mut boss_bars_query: Query<
         (
             &mut BossBarStyle,
@@ -158,9 +158,9 @@ fn listen_messages(
         entity_layer_id,
     ) = boss_bars_query.single_mut().unwrap();
 
-    for ChatMessageEvent {
+    for ChatMessageMessage {
         client, message, ..
-    } in message_events.read()
+    } in message_messages.read()
     {
         match message.as_ref() {
             "view" => {

--- a/examples/building.rs
+++ b/examples/building.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-use chunkedge::interact_block::InteractBlockEvent;
+use chunkedge::interact_block::InteractBlockMessage;
 use chunkedge::inventory::HeldItem;
 use chunkedge::prelude::*;
 
@@ -85,13 +85,13 @@ fn init_clients(
 
 fn toggle_gamemode_on_sneak(
     mut clients: Query<&mut GameMode>,
-    mut events: MessageReader<SneakEvent>,
+    mut messages: MessageReader<SneakMessage>,
 ) {
-    for event in events.read() {
-        let Ok(mut mode) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok(mut mode) = clients.get_mut(message.client) else {
             continue;
         };
-        if event.state == SneakState::Start {
+        if message.state == SneakState::Start {
             *mode = match *mode {
                 GameMode::Survival => GameMode::Creative,
                 GameMode::Creative => GameMode::Survival,
@@ -104,19 +104,19 @@ fn toggle_gamemode_on_sneak(
 fn digging(
     clients: Query<&GameMode>,
     mut layers: Query<&mut ChunkLayer>,
-    mut events: MessageReader<DiggingEvent>,
+    mut messages: MessageReader<DiggingMessage>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for event in events.read() {
-        let Ok(game_mode) = clients.get(event.client) else {
+    for message in messages.read() {
+        let Ok(game_mode) = clients.get(message.client) else {
             continue;
         };
 
-        if (*game_mode == GameMode::Creative && event.state == DiggingState::Start)
-            || (*game_mode == GameMode::Survival && event.state == DiggingState::Stop)
+        if (*game_mode == GameMode::Creative && message.state == DiggingState::Start)
+            || (*game_mode == GameMode::Survival && message.state == DiggingState::Stop)
         {
-            layer.set_block(event.position, BlockState::AIR);
+            layer.set_block(message.position, BlockState::AIR);
         }
     }
 }
@@ -124,15 +124,15 @@ fn digging(
 fn place_blocks(
     mut clients: Query<(&mut Inventory, &GameMode, &HeldItem)>,
     mut layers: Query<&mut ChunkLayer>,
-    mut events: MessageReader<InteractBlockEvent>,
+    mut messages: MessageReader<InteractBlockMessage>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for event in events.read() {
-        let Ok((mut inventory, game_mode, held)) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok((mut inventory, game_mode, held)) = clients.get_mut(message.client) else {
             continue;
         };
-        if event.hand != Hand::Main {
+        if message.hand != Hand::Main {
             continue;
         }
 
@@ -159,10 +159,10 @@ fn place_blocks(
                 inventory.set_slot(slot_id, ItemStack::EMPTY);
             }
         }
-        let real_pos = event.position.get_in_direction(event.face);
+        let real_pos = message.position.get_in_direction(message.face);
         let state = block_kind.to_state().set(
             PropName::Axis,
-            match event.face {
+            match message.face {
                 Direction::Down | Direction::Up => PropValue::Y,
                 Direction::North | Direction::South => PropValue::Z,
                 Direction::West | Direction::East => PropValue::X,

--- a/examples/chest.rs
+++ b/examples/chest.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-use chunkedge::interact_block::InteractBlockEvent;
+use chunkedge::interact_block::InteractBlockMessage;
 use chunkedge::prelude::*;
 
 const SPAWN_Y: i32 = 64;
@@ -89,14 +89,14 @@ fn init_clients(
 
 fn toggle_gamemode_on_sneak(
     mut clients: Query<&mut GameMode>,
-    mut events: MessageReader<SneakEvent>,
+    mut messages: MessageReader<SneakMessage>,
 ) {
-    for event in events.read() {
-        let Ok(mut mode) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok(mut mode) = clients.get_mut(message.client) else {
             continue;
         };
 
-        if event.state == SneakState::Start {
+        if message.state == SneakState::Start {
             *mode = match *mode {
                 GameMode::Survival => GameMode::Creative,
                 GameMode::Creative => GameMode::Survival,
@@ -109,13 +109,13 @@ fn toggle_gamemode_on_sneak(
 fn open_chest(
     mut commands: Commands,
     inventories: Query<Entity, (With<Inventory>, Without<Client>)>,
-    mut events: MessageReader<InteractBlockEvent>,
+    mut messages: MessageReader<InteractBlockMessage>,
 ) {
-    for event in events.read() {
-        if event.position != CHEST_POS.into() {
+    for message in messages.read() {
+        if message.position != CHEST_POS.into() {
             continue;
         }
         let open_inventory = OpenInventory::new(inventories.single().unwrap());
-        commands.entity(event.client).insert(open_inventory);
+        commands.entity(message.client).insert(open_inventory);
     }
 }

--- a/examples/combat.rs
+++ b/examples/combat.rs
@@ -21,7 +21,7 @@ pub fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(EventLoopUpdate, handle_combat_events)
+        .add_systems(EventLoopUpdate, handle_combat_messages)
         .add_systems(
             Update,
             (
@@ -118,19 +118,19 @@ struct CombatQuery {
     statuses: &'static mut EntityStatuses,
 }
 
-fn handle_combat_events(
+fn handle_combat_messages(
     server: Res<Server>,
     mut clients: Query<CombatQuery>,
-    mut sprinting: MessageReader<SprintEvent>,
-    mut interact_entity: MessageReader<InteractEntityEvent>,
+    mut sprinting: MessageReader<SprintMessage>,
+    mut interact_entity: MessageReader<InteractEntityMessage>,
 ) {
-    for &SprintEvent { client, state } in sprinting.read() {
+    for &SprintMessage { client, state } in sprinting.read() {
         if let Ok(mut client) = clients.get_mut(client) {
             client.state.has_bonus_knockback = state == SprintState::Start;
         }
     }
 
-    for &InteractEntityEvent {
+    for &InteractEntityMessage {
         client: attacker_client,
         entity: victim_client,
         ..

--- a/examples/command.rs
+++ b/examples/command.rs
@@ -7,7 +7,7 @@ use chunkedge::prelude::*;
 use chunkedge::*;
 use chunkedge_server::op_level::OpLevel;
 use command::graph::CommandGraphBuilder;
-use command::handler::CommandResultEvent;
+use command::handler::CommandResultMessage;
 use command::parsers::entity_selector::{EntitySelector, EntitySelectors};
 use command::parsers::{CommandArg, GreedyString, QuotableString};
 use command::scopes::CommandScopes;
@@ -206,21 +206,21 @@ enum TeleportDestination {
 }
 
 fn handle_teleport_command(
-    mut events: MessageReader<CommandResultEvent<TeleportCommand>>,
+    mut messages: MessageReader<CommandResultMessage<TeleportCommand>>,
     living_entities: Query<Entity, With<LivingEntity>>,
     mut clients: Query<(Entity, &mut Client)>,
     entity_layers: Query<&EntityLayerId>,
     mut positions: Query<&mut Position>,
     usernames: Query<(Entity, &Username)>,
 ) {
-    for event in events.read() {
-        let compiled_command = match &event.result {
+    for message in messages.read() {
+        let compiled_command = match &message.result {
             TeleportCommand::ExecutorToLocation { location } => (
-                TeleportTarget::Targets(vec![event.executor]),
+                TeleportTarget::Targets(vec![message.executor]),
                 TeleportDestination::Location(*location),
             ),
             TeleportCommand::ExecutorToTarget { target } => (
-                TeleportTarget::Targets(vec![event.executor]),
+                TeleportTarget::Targets(vec![message.executor]),
                 TeleportDestination::Target(
                     find_targets(
                         &living_entities,
@@ -228,7 +228,7 @@ fn handle_teleport_command(
                         &positions,
                         &entity_layers,
                         &usernames,
-                        event,
+                        message,
                         target,
                     )
                     .first()
@@ -243,7 +243,7 @@ fn handle_teleport_command(
                         &positions,
                         &entity_layers,
                         &usernames,
-                        event,
+                        message,
                         from,
                     )
                     .clone(),
@@ -255,7 +255,7 @@ fn handle_teleport_command(
                         &positions,
                         &entity_layers,
                         &usernames,
-                        event,
+                        message,
                         to,
                     )
                     .first()
@@ -270,7 +270,7 @@ fn handle_teleport_command(
                         &positions,
                         &entity_layers,
                         &usernames,
-                        event,
+                        message,
                         target,
                     )
                     .clone(),
@@ -309,13 +309,13 @@ fn find_targets(
     positions: &Query<&mut Position>,
     entity_layers: &Query<&EntityLayerId>,
     usernames: &Query<(Entity, &Username)>,
-    event: &CommandResultEvent<TeleportCommand>,
+    message: &CommandResultMessage<TeleportCommand>,
     target: &EntitySelector,
 ) -> Vec<Entity> {
     match target {
         EntitySelector::SimpleSelector(selector) => match selector {
             EntitySelectors::AllEntities => {
-                let executor_entity_layer = *entity_layers.get(event.executor).unwrap();
+                let executor_entity_layer = *entity_layers.get(message.executor).unwrap();
                 living_entities
                     .iter()
                     .filter(|entity| {
@@ -328,7 +328,7 @@ fn find_targets(
                 let target = usernames.iter().find(|(_, username)| username.0 == *name);
                 match target {
                     None => {
-                        let client = &mut clients.get_mut(event.executor).unwrap().1;
+                        let client = &mut clients.get_mut(message.executor).unwrap().1;
                         client.send_chat_message(format!("Could not find target: {name}"));
                         vec![]
                     }
@@ -338,7 +338,7 @@ fn find_targets(
                 }
             }
             EntitySelectors::AllPlayers => {
-                let executor_entity_layer = *entity_layers.get(event.executor).unwrap();
+                let executor_entity_layer = *entity_layers.get(message.executor).unwrap();
                 clients
                     .iter_mut()
                     .filter_map(|(entity, ..)| {
@@ -352,17 +352,17 @@ fn find_targets(
                     .collect()
             }
             EntitySelectors::SelfPlayer => {
-                vec![event.executor]
+                vec![message.executor]
             }
             EntitySelectors::NearestPlayer => {
-                let executor_entity_layer = *entity_layers.get(event.executor).unwrap();
-                let executor_pos = positions.get(event.executor).unwrap();
+                let executor_entity_layer = *entity_layers.get(message.executor).unwrap();
+                let executor_pos = positions.get(message.executor).unwrap();
                 let target = clients
                     .iter_mut()
                     .filter(|(entity, ..)| {
                         *entity_layers.get(*entity).unwrap() == executor_entity_layer
                     })
-                    .filter(|(target, ..)| *target != event.executor)
+                    .filter(|(target, ..)| *target != message.executor)
                     .map(|(target, ..)| target)
                     .min_by(|target, target2| {
                         let target_pos = positions.get(*target).unwrap();
@@ -373,7 +373,7 @@ fn find_targets(
                     });
                 match target {
                     None => {
-                        let mut client = clients.get_mut(event.executor).unwrap().1;
+                        let mut client = clients.get_mut(message.executor).unwrap().1;
                         client.send_chat_message("Could not find target".to_owned());
                         vec![]
                     }
@@ -383,7 +383,7 @@ fn find_targets(
                 }
             }
             EntitySelectors::RandomPlayer => {
-                let executor_entity_layer = *entity_layers.get(event.executor).unwrap();
+                let executor_entity_layer = *entity_layers.get(message.executor).unwrap();
                 let target = clients
                     .iter_mut()
                     .filter(|(entity, ..)| {
@@ -393,7 +393,7 @@ fn find_targets(
                     .map(|(target, ..)| target);
                 match target {
                     None => {
-                        let mut client = clients.get_mut(event.executor).unwrap().1;
+                        let mut client = clients.get_mut(message.executor).unwrap().1;
                         client.send_chat_message("Could not find target".to_owned());
                         vec![]
                     }
@@ -404,7 +404,7 @@ fn find_targets(
             }
         },
         EntitySelector::ComplexSelector(_, _) => {
-            let mut client = clients.get_mut(event.executor).unwrap().1;
+            let mut client = clients.get_mut(message.executor).unwrap().1;
             client.send_chat_message("complex selector not implemented".to_owned());
             vec![]
         }
@@ -412,58 +412,58 @@ fn find_targets(
 }
 
 fn handle_test_command(
-    mut events: MessageReader<CommandResultEvent<TestCommand>>,
+    mut messages: MessageReader<CommandResultMessage<TestCommand>>,
     mut clients: Query<&mut Client>,
 ) {
-    for event in events.read() {
-        let client = &mut clients.get_mut(event.executor).unwrap();
+    for message in messages.read() {
+        let client = &mut clients.get_mut(message.executor).unwrap();
         client.send_chat_message(format!(
             "Test command executed with data:\n {:#?}",
-            &event.result
+            &message.result
         ));
     }
 }
 
 fn handle_complex_command(
-    mut events: MessageReader<CommandResultEvent<ComplexRedirectionCommand>>,
+    mut messages: MessageReader<CommandResultMessage<ComplexRedirectionCommand>>,
     mut clients: Query<&mut Client>,
 ) {
-    for event in events.read() {
-        let client = &mut clients.get_mut(event.executor).unwrap();
+    for message in messages.read() {
+        let client = &mut clients.get_mut(message.executor).unwrap();
         client.send_chat_message(format!(
             "complex command executed with data:\n {:#?}\n and with the modifiers:\n {:#?}",
-            &event.result, &event.modifiers
+            &message.result, &message.modifiers
         ));
     }
 }
 
 fn handle_struct_command(
-    mut events: MessageReader<CommandResultEvent<StructCommand>>,
+    mut messages: MessageReader<CommandResultMessage<StructCommand>>,
     mut clients: Query<&mut Client>,
 ) {
-    for event in events.read() {
-        let client = &mut clients.get_mut(event.executor).unwrap();
+    for message in messages.read() {
+        let client = &mut clients.get_mut(message.executor).unwrap();
         client.send_chat_message(format!(
             "Struct command executed with data:\n {:#?}",
-            &event.result
+            &message.result
         ));
     }
 }
 
 fn handle_gamemode_command(
-    mut events: MessageReader<CommandResultEvent<GamemodeCommand>>,
+    mut messages: MessageReader<CommandResultMessage<GamemodeCommand>>,
     mut clients: Query<(&mut Client, &mut GameMode, &Username, Entity)>,
     positions: Query<&Position>,
 ) {
-    for event in events.read() {
-        let game_mode_to_set = match &event.result {
+    for message in messages.read() {
+        let game_mode_to_set = match &message.result {
             GamemodeCommand::Survival { .. } => GameMode::Survival,
             GamemodeCommand::Creative { .. } => GameMode::Creative,
             GamemodeCommand::Adventure { .. } => GameMode::Adventure,
             GamemodeCommand::Spectator { .. } => GameMode::Spectator,
         };
 
-        let selector = match &event.result {
+        let selector = match &message.result {
             GamemodeCommand::Survival { target } => target.clone(),
             GamemodeCommand::Creative { target } => target.clone(),
             GamemodeCommand::Adventure { target } => target.clone(),
@@ -472,11 +472,11 @@ fn handle_gamemode_command(
 
         match selector {
             None => {
-                let (mut client, mut game_mode, ..) = clients.get_mut(event.executor).unwrap();
+                let (mut client, mut game_mode, ..) = clients.get_mut(message.executor).unwrap();
                 *game_mode = game_mode_to_set;
                 client.send_chat_message(format!(
                     "Gamemode command executor -> self executed with data:\n {:#?}",
-                    &event.result
+                    &message.result
                 ));
             }
             Some(selector) => match selector {
@@ -487,7 +487,7 @@ fn handle_gamemode_command(
                             client.send_chat_message(format!(
                                 "Gamemode command executor -> all entities executed with data:\n \
                                  {:#?}",
-                                &event.result
+                                &message.result
                             ));
                         }
                     }
@@ -499,18 +499,18 @@ fn handle_gamemode_command(
 
                         match target {
                             None => {
-                                let client = &mut clients.get_mut(event.executor).unwrap().0;
+                                let client = &mut clients.get_mut(message.executor).unwrap().0;
                                 client.send_chat_message(format!("Could not find target: {name}"));
                             }
                             Some(target) => {
                                 let mut game_mode = clients.get_mut(target).unwrap().1;
                                 *game_mode = game_mode_to_set;
 
-                                let client = &mut clients.get_mut(event.executor).unwrap().0;
+                                let client = &mut clients.get_mut(message.executor).unwrap().0;
                                 client.send_chat_message(format!(
                                     "Gamemode command executor -> single player executed with \
                                      data:\n {:#?}",
-                                    &event.result
+                                    &message.result
                                 ));
                             }
                         }
@@ -521,24 +521,24 @@ fn handle_gamemode_command(
                             client.send_chat_message(format!(
                                 "Gamemode command executor -> all entities executed with data:\n \
                                  {:#?}",
-                                &event.result
+                                &message.result
                             ));
                         }
                     }
                     EntitySelectors::SelfPlayer => {
                         let (mut client, mut game_mode, ..) =
-                            clients.get_mut(event.executor).unwrap();
+                            clients.get_mut(message.executor).unwrap();
                         *game_mode = game_mode_to_set;
                         client.send_chat_message(format!(
                             "Gamemode command executor -> self executed with data:\n {:#?}",
-                            &event.result
+                            &message.result
                         ));
                     }
                     EntitySelectors::NearestPlayer => {
-                        let executor_pos = positions.get(event.executor).unwrap();
+                        let executor_pos = positions.get(message.executor).unwrap();
                         let target = clients
                             .iter_mut()
-                            .filter(|(.., target)| *target != event.executor)
+                            .filter(|(.., target)| *target != message.executor)
                             .min_by(|(.., target), (.., target2)| {
                                 let target_pos = positions.get(*target).unwrap();
                                 let target2_pos = positions.get(*target2).unwrap();
@@ -550,18 +550,18 @@ fn handle_gamemode_command(
 
                         match target {
                             None => {
-                                let client = &mut clients.get_mut(event.executor).unwrap().0;
+                                let client = &mut clients.get_mut(message.executor).unwrap().0;
                                 client.send_chat_message("Could not find target".to_owned());
                             }
                             Some(target) => {
                                 let mut game_mode = clients.get_mut(target).unwrap().1;
                                 *game_mode = game_mode_to_set;
 
-                                let client = &mut clients.get_mut(event.executor).unwrap().0;
+                                let client = &mut clients.get_mut(message.executor).unwrap().0;
                                 client.send_chat_message(format!(
                                     "Gamemode command executor -> single player executed with \
                                      data:\n {:#?}",
-                                    &event.result
+                                    &message.result
                                 ));
                             }
                         }
@@ -574,25 +574,25 @@ fn handle_gamemode_command(
 
                         match target {
                             None => {
-                                let client = &mut clients.get_mut(event.executor).unwrap().0;
+                                let client = &mut clients.get_mut(message.executor).unwrap().0;
                                 client.send_chat_message("Could not find target".to_owned());
                             }
                             Some(target) => {
                                 let mut game_mode = clients.get_mut(target).unwrap().1;
                                 *game_mode = game_mode_to_set;
 
-                                let client = &mut clients.get_mut(event.executor).unwrap().0;
+                                let client = &mut clients.get_mut(message.executor).unwrap().0;
                                 client.send_chat_message(format!(
                                     "Gamemode command executor -> single player executed with \
                                      data:\n {:#?}",
-                                    &event.result
+                                    &message.result
                                 ));
                             }
                         }
                     }
                 },
                 EntitySelector::ComplexSelector(_, _) => {
-                    let client = &mut clients.get_mut(event.executor).unwrap().0;
+                    let client = &mut clients.get_mut(message.executor).unwrap().0;
                     client
                         .send_chat_message("Complex selectors are not implemented yet".to_owned());
                 }

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -2,7 +2,7 @@
 
 use std::f64::consts::TAU;
 
-use chunkedge::abilities::{PlayerStartFlyingEvent, PlayerStopFlyingEvent};
+use chunkedge::abilities::{PlayerStartFlyingMessage, PlayerStopFlyingMessage};
 use chunkedge::math::{DQuat, EulerRot};
 use chunkedge::message::SendMessage;
 use chunkedge::prelude::*;
@@ -152,18 +152,18 @@ fn lerp(a: f64, b: f64, t: f64) -> f64 {
 
 // Send an actionbar message to all clients when their flying state changes.
 fn display_is_flying(
-    mut player_start_flying_events: MessageReader<PlayerStartFlyingEvent>,
-    mut player_stop_flying_events: MessageReader<PlayerStopFlyingEvent>,
+    mut player_start_flying_messages: MessageReader<PlayerStartFlyingMessage>,
+    mut player_stop_flying_messages: MessageReader<PlayerStopFlyingMessage>,
     mut clients: Query<&mut Client>,
 ) {
-    for event in player_start_flying_events.read() {
-        if let Ok(mut client) = clients.get_mut(event.client) {
+    for message in player_start_flying_messages.read() {
+        if let Ok(mut client) = clients.get_mut(message.client) {
             client.send_action_bar_message("You are flying!".color(NamedColor::Green));
         }
     }
 
-    for event in player_stop_flying_events.read() {
-        if let Ok(mut client) = clients.get_mut(event.client) {
+    for message in player_stop_flying_messages.read() {
+        if let Ok(mut client) = clients.get_mut(message.client) {
             client.send_action_bar_message("You are no longer flying!".color(NamedColor::Red));
         }
     }

--- a/examples/ctf.rs
+++ b/examples/ctf.rs
@@ -9,14 +9,14 @@ use chunkedge::entity::living::Health;
 use chunkedge::entity::pig::PigEntityBundle;
 use chunkedge::entity::player::PlayerEntityBundle;
 use chunkedge::entity::{EntityAnimations, EntityStatuses, OnGround, Velocity};
-use chunkedge::interact_block::InteractBlockEvent;
+use chunkedge::interact_block::InteractBlockMessage;
 use chunkedge::inventory::HeldItem;
 use chunkedge::log::debug;
 use chunkedge::math::{Aabb, Vec3Swizzles};
 use chunkedge::nbt::{compound, List};
 use chunkedge::prelude::*;
 use chunkedge::scoreboard::*;
-use chunkedge::status::RequestRespawnEvent;
+use chunkedge::status::RequestRespawnMessage;
 
 const ARENA_Y: i32 = 64;
 const ARENA_MID_WIDTH: i32 = 2;
@@ -38,7 +38,7 @@ pub fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(EventLoopUpdate, handle_combat_events)
+        .add_systems(EventLoopUpdate, handle_combat_messages)
         .add_systems(
             Update,
             (
@@ -436,35 +436,37 @@ impl Team {
 fn digging(
     mut clients: Query<(&GameMode, &Team, Entity, &mut Client, &mut Inventory)>,
     mut layers: Query<&mut ChunkLayer>,
-    mut events: MessageReader<DiggingEvent>,
+    mut messages: MessageReader<DiggingMessage>,
     mut commands: Commands,
     globals: Res<CtfGlobals>,
     mut flag_manager: ResMut<FlagManager>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for event in events.read() {
-        let Ok((game_mode, team, ent, mut client, mut inv)) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok((game_mode, team, ent, mut client, mut inv)) = clients.get_mut(message.client)
+        else {
             continue;
         };
 
-        if (*game_mode == GameMode::Creative && event.state == DiggingState::Start)
-            || (*game_mode == GameMode::Survival && event.state == DiggingState::Stop)
+        if (*game_mode == GameMode::Creative && message.state == DiggingState::Start)
+            || (*game_mode == GameMode::Survival && message.state == DiggingState::Stop)
         {
-            let Some(block) = layer.block(event.position) else {
+            let Some(block) = layer.block(message.position) else {
                 continue;
             };
-            let is_flag = event.position == globals.red_flag || event.position == globals.blue_flag;
+            let is_flag =
+                message.position == globals.red_flag || message.position == globals.blue_flag;
 
             match (team, block.state) {
-                (Team::Blue, BlockState::RED_WOOL) if event.position == globals.red_flag => {
-                    commands.entity(event.client).insert(HasFlag(Team::Red));
+                (Team::Blue, BlockState::RED_WOOL) if message.position == globals.red_flag => {
+                    commands.entity(message.client).insert(HasFlag(Team::Red));
                     client.send_chat_message("You have the flag!".italic());
                     flag_manager.red = Some(ent);
                     return;
                 }
-                (Team::Red, BlockState::BLUE_WOOL) if event.position == globals.blue_flag => {
-                    commands.entity(event.client).insert(HasFlag(Team::Blue));
+                (Team::Red, BlockState::BLUE_WOOL) if message.position == globals.blue_flag => {
+                    commands.entity(message.client).insert(HasFlag(Team::Blue));
                     client.send_chat_message("You have the flag!".italic());
                     flag_manager.blue = Some(ent);
                     return;
@@ -472,14 +474,14 @@ fn digging(
                 _ => {}
             }
 
-            if event.position.y <= ARENA_Y
+            if message.position.y <= ARENA_Y
                 || block.state.to_kind() == BlockKind::OakFence
                 || is_flag
             {
                 continue;
             }
 
-            let prev = layer.set_block(event.position, BlockState::AIR);
+            let prev = layer.set_block(message.position, BlockState::AIR);
 
             if let Some(prev) = prev {
                 let kind: ItemKind = prev.state.to_kind().to_item_kind();
@@ -503,15 +505,15 @@ fn place_blocks(
     mut clients: Query<(&mut Inventory, &GameMode, &HeldItem, &Hitbox)>,
     mut layers: Query<&mut ChunkLayer>,
     globals: Res<CtfGlobals>,
-    mut events: MessageReader<InteractBlockEvent>,
+    mut messages: MessageReader<InteractBlockMessage>,
 ) {
     let mut layer = layers.single_mut().unwrap();
 
-    for event in events.read() {
-        let Ok((mut inventory, game_mode, held, hitbox)) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok((mut inventory, game_mode, held, hitbox)) = clients.get_mut(message.client) else {
             continue;
         };
-        if event.hand != Hand::Main {
+        if message.hand != Hand::Main {
             continue;
         }
 
@@ -526,7 +528,7 @@ fn place_blocks(
             // can't place this item as a block
             continue;
         };
-        let real_pos = event.position.get_in_direction(event.face);
+        let real_pos = message.position.get_in_direction(message.face);
 
         // Can't place blocks on the flag positions
         if real_pos == globals.red_flag || real_pos == globals.blue_flag {
@@ -944,20 +946,20 @@ struct CombatQuery {
     team: &'static Team,
 }
 
-fn handle_combat_events(
+fn handle_combat_messages(
     server: Res<Server>,
     mut clients: Query<CombatQuery>,
-    mut sprinting: MessageReader<SprintEvent>,
-    mut interact_entity: MessageReader<InteractEntityEvent>,
+    mut sprinting: MessageReader<SprintMessage>,
+    mut interact_entity: MessageReader<InteractEntityMessage>,
     clones: Query<&ClonedEntity>,
 ) {
-    for &SprintEvent { client, state } in sprinting.read() {
+    for &SprintMessage { client, state } in sprinting.read() {
         if let Ok(mut client) = clients.get_mut(client) {
             client.state.has_bonus_knockback = state == SprintState::Start;
         }
     }
 
-    for &InteractEntityEvent {
+    for &InteractEntityMessage {
         client: attacker_client,
         entity: victim_client,
         ..
@@ -969,7 +971,7 @@ fn handle_combat_events(
         let Ok([mut attacker, mut victim]) =
             clients.get_many_mut([attacker_client, true_victim_ent])
         else {
-            debug!("Failed to get clients for combat event");
+            debug!("Failed to get clients for combat message");
             // Victim or attacker does not exist, or the attacker is attacking itself.
             continue;
         };
@@ -1041,12 +1043,12 @@ fn necromancy(
         &Team,
         &mut Health,
     )>,
-    mut events: MessageReader<RequestRespawnEvent>,
+    mut messages: MessageReader<RequestRespawnMessage>,
     layers: Query<Entity, (With<ChunkLayer>, With<EntityLayer>)>,
 ) {
-    for event in events.read() {
+    for message in messages.read() {
         if let Ok((mut visible_chunk_layer, mut respawn_pos, team, mut health)) =
-            clients.get_mut(event.client)
+            clients.get_mut(message.client)
         {
             respawn_pos.pos = team.spawn_pos().into();
             health.0 = PLAYER_MAX_HEALTH;

--- a/examples/death.rs
+++ b/examples/death.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use chunkedge::prelude::*;
-use chunkedge::status::RequestRespawnEvent;
+use chunkedge::status::RequestRespawnMessage;
 
 const SPAWN_Y: i32 = 64;
 
@@ -87,10 +87,10 @@ fn init_clients(
     }
 }
 
-fn squat_and_die(mut clients: Query<&mut Client>, mut events: MessageReader<SneakEvent>) {
-    for event in events.read() {
-        if event.state == SneakState::Start {
-            if let Ok(mut client) = clients.get_mut(event.client) {
+fn squat_and_die(mut clients: Query<&mut Client>, mut messages: MessageReader<SneakMessage>) {
+    for message in messages.read() {
+        if message.state == SneakState::Start {
+            if let Ok(mut client) = clients.get_mut(message.client) {
                 client.kill("Squatted too hard.");
             }
         }
@@ -104,16 +104,16 @@ fn necromancy(
         &mut VisibleEntityLayers,
         &mut RespawnPosition,
     )>,
-    mut events: MessageReader<RequestRespawnEvent>,
+    mut messages: MessageReader<RequestRespawnMessage>,
     layers: Query<Entity, (With<ChunkLayer>, With<EntityLayer>)>,
 ) {
-    for event in events.read() {
+    for message in messages.read() {
         if let Ok((
             mut layer_id,
             mut visible_chunk_layer,
             mut visible_entity_layers,
             mut respawn_pos,
-        )) = clients.get_mut(event.client)
+        )) = clients.get_mut(message.client)
         {
             respawn_pos.pos = BlockPos::new(0, SPAWN_Y, 0);
 

--- a/examples/entity_hitbox.rs
+++ b/examples/entity_hitbox.rs
@@ -83,7 +83,7 @@ fn init_clients(
 
 fn spawn_entity(
     mut commands: Commands,
-    mut sneaking: MessageReader<SneakEvent>,
+    mut sneaking: MessageReader<SneakMessage>,
     client_query: Query<(&Position, &EntityLayerId)>,
 ) {
     for sneaking in sneaking.read() {

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -172,10 +172,10 @@ impl LifeBoard {
     }
 }
 
-fn toggle_cell_on_dig(mut events: MessageReader<DiggingEvent>, mut board: ResMut<LifeBoard>) {
-    for event in events.read() {
-        if event.state == DiggingState::Start {
-            let (x, z) = (event.position.x, event.position.z);
+fn toggle_cell_on_dig(mut messages: MessageReader<DiggingMessage>, mut board: ResMut<LifeBoard>) {
+    for message in messages.read() {
+        if message.state == DiggingState::Start {
+            let (x, z) = (message.position.x, message.position.z);
 
             let live = board.get(x, z);
             board.set(x, z, !live);
@@ -208,12 +208,12 @@ fn update_board(
 }
 
 fn pause_on_crouch(
-    mut events: MessageReader<SneakEvent>,
+    mut messages: MessageReader<SneakMessage>,
     mut board: ResMut<LifeBoard>,
     mut layers: Query<&mut EntityLayer>,
 ) {
-    for event in events.read() {
-        if event.state == SneakState::Start {
+    for message in messages.read() {
+        if message.state == SneakState::Start {
             let mut layer = layers.single_mut().unwrap();
 
             if board.playing {

--- a/examples/item_menu.rs
+++ b/examples/item_menu.rs
@@ -6,12 +6,12 @@
 
 const SPAWN_Y: i32 = 64;
 
-use chunkedge::interact_item::InteractItemEvent;
+use chunkedge::interact_item::InteractItemMessage;
 use chunkedge::prelude::*;
 use chunkedge::protocol::sound::SoundCategory;
 use chunkedge::protocol::Sound;
 use chunkedge_inventory::HeldItem;
-use item_menu::{ItemMenu, ItemMenuPlugin, MenuItemSelectEvent};
+use item_menu::{ItemMenu, ItemMenuPlugin, MenuItemSelectMessage};
 
 pub fn main() {
     App::new()
@@ -94,10 +94,10 @@ fn init_clients(
 fn on_item_interact(
     mut commands: Commands,
     clients: Query<(Entity, &HeldItem, &Inventory)>,
-    mut events: MessageReader<InteractItemEvent>,
+    mut messages: MessageReader<InteractItemMessage>,
 ) {
-    for event in events.read() {
-        let Ok((player_ent, held_item, inventory)) = clients.get(event.client) else {
+    for message in messages.read() {
+        let Ok((player_ent, held_item, inventory)) = clients.get(message.client) else {
             continue;
         };
         if *inventory.slot(held_item.slot()) == ItemStack::new(ItemKind::Compass, 1) {
@@ -118,14 +118,14 @@ fn open_menu(commands: &mut Commands, player: Entity) {
 
 fn on_make_selection(
     mut clients: Query<(&mut Client, &Position)>,
-    mut events: MessageReader<MenuItemSelectEvent>,
+    mut messages: MessageReader<MenuItemSelectMessage>,
 ) {
-    for event in events.read() {
-        let Ok((mut client, pos)) = clients.get_mut(event.client) else {
+    for message in messages.read() {
+        let Ok((mut client, pos)) = clients.get_mut(message.client) else {
             continue;
         };
 
-        let selected_color = match event.idx {
+        let selected_color = match message.idx {
             3 => "§cRED",
             5 => "§aGREEN",
             _ => continue,
@@ -144,21 +144,21 @@ fn on_make_selection(
 
 mod item_menu {
     use chunkedge::prelude::*;
-    use chunkedge_inventory::ClickSlotEvent;
+    use chunkedge_inventory::ClickSlotMessage;
 
     pub(crate) struct ItemMenuPlugin;
 
     impl Plugin for ItemMenuPlugin {
         fn build(&self, app: &mut App) {
             app.add_systems(Update, (open_menu, select_menu_item))
-                .add_message::<MenuItemSelectEvent>()
+                .add_message::<MenuItemSelectMessage>()
                 .add_observer(close_menu);
         }
     }
 
-    /// This event is fired when the player interacts with an item in the menu.
+    /// This message is fired when the player interacts with an item in the menu.
     #[derive(Debug, Clone, PartialEq, Eq, Message)]
-    pub(crate) struct MenuItemSelectEvent {
+    pub(crate) struct MenuItemSelectMessage {
         /// Player entity
         pub client: Entity,
         /// Index of the item in the menu
@@ -206,12 +206,12 @@ mod item_menu {
 
     fn select_menu_item(
         mut clients: Query<(Entity, &ItemMenu)>,
-        mut events: MessageReader<ClickSlotEvent>,
-        mut event_writer: MessageWriter<MenuItemSelectEvent>,
+        mut messages: MessageReader<ClickSlotMessage>,
+        mut message_writer: MessageWriter<MenuItemSelectMessage>,
     ) {
-        for event in events.read() {
-            let selected_slot = event.slot_id;
-            let Ok((player, item_menu)) = clients.get_mut(event.client) else {
+        for message in messages.read() {
+            let selected_slot = message.slot_id;
+            let Ok((player, item_menu)) = clients.get_mut(message.client) else {
                 continue;
             };
             // check that the selected item is not in the player's own inventory
@@ -219,7 +219,7 @@ mod item_menu {
                 continue;
             }
 
-            event_writer.write(MenuItemSelectEvent {
+            message_writer.write(MenuItemSelectMessage {
                 client: player,
                 idx: selected_slot as u16,
             });

--- a/examples/potions.rs
+++ b/examples/potions.rs
@@ -135,12 +135,12 @@ fn init_clients(
 
 pub fn add_potion_effect(
     mut clients: Query<&mut ActiveStatusEffects>,
-    mut events: MessageReader<SneakEvent>,
+    mut messages: MessageReader<SneakMessage>,
 ) {
     let mut rng = rand::rng();
-    for event in events.read() {
-        if event.state == SneakState::Start {
-            if let Ok(mut status) = clients.get_mut(event.client) {
+    for message in messages.read() {
+        if message.state == SneakState::Start {
+            if let Ok(mut status) = clients.get_mut(message.client) {
                 status.apply(
                     ActiveStatusEffect::from_effect(*StatusEffect::ALL.choose(&mut rng).unwrap())
                         .with_duration(rng.random_range(10..1000))
@@ -208,15 +208,15 @@ pub fn handle_status_effect_added(
         Option<&mut Absorption>,
         &mut Flags,
     )>,
-    mut events: MessageReader<StatusEffectAdded>,
+    mut messages: MessageReader<StatusEffectAdded>,
 ) {
-    for event in events.read() {
+    for message in messages.read() {
         if let Ok((status, mut attributes, mut health, absorption, mut flags)) =
-            clients.get_mut(event.entity)
+            clients.get_mut(message.entity)
         {
-            let effect = status.get_current_effect(event.status_effect).unwrap();
+            let effect = status.get_current_effect(message.status_effect).unwrap();
 
-            match event.status_effect {
+            match message.status_effect {
                 StatusEffect::Absorption => {
                     // not quite how vanilla does it. if you want to do it the vanilla way, you'll
                     // need to keep track of the previous absorption value and subtract that from
@@ -264,13 +264,13 @@ pub fn handle_status_effect_removed(
         Option<&mut Absorption>,
         &mut Flags,
     )>,
-    mut events: MessageReader<StatusEffectRemoved>,
+    mut messages: MessageReader<StatusEffectRemoved>,
 ) {
-    for event in events.read() {
+    for message in messages.read() {
         if let Ok((mut attributes, mut health, absorption, mut flags)) =
-            clients.get_mut(event.entity)
+            clients.get_mut(message.entity)
         {
-            let effect = &event.status_effect;
+            let effect = &message.status_effect;
             match effect.status_effect() {
                 StatusEffect::Absorption => {
                     if let Some(mut absorption) = absorption {

--- a/examples/potions.rs
+++ b/examples/potions.rs
@@ -7,7 +7,7 @@ use chunkedge::status_effects::{AttributeModifier, StatusEffect};
 use chunkedge_server::entity::attributes::{EntityAttribute, EntityAttributes};
 use chunkedge_server::entity::entity::Flags;
 use chunkedge_server::entity::living::{Absorption, Health};
-use chunkedge_server::status_effect::{StatusEffectAdded, StatusEffectRemovedMessage};
+use chunkedge_server::status_effect::{StatusEffectAddedMessage, StatusEffectRemovedMessage};
 use rand::seq::IndexedRandom;
 use rand::RngExt;
 
@@ -208,7 +208,7 @@ pub fn handle_status_effect_added(
         Option<&mut Absorption>,
         &mut Flags,
     )>,
-    mut messages: MessageReader<StatusEffectAdded>,
+    mut messages: MessageReader<StatusEffectAddedMessage>,
 ) {
     for message in messages.read() {
         if let Ok((status, mut attributes, mut health, absorption, mut flags)) =

--- a/examples/potions.rs
+++ b/examples/potions.rs
@@ -7,7 +7,7 @@ use chunkedge::status_effects::{AttributeModifier, StatusEffect};
 use chunkedge_server::entity::attributes::{EntityAttribute, EntityAttributes};
 use chunkedge_server::entity::entity::Flags;
 use chunkedge_server::entity::living::{Absorption, Health};
-use chunkedge_server::status_effect::{StatusEffectAdded, StatusEffectRemoved};
+use chunkedge_server::status_effect::{StatusEffectAdded, StatusEffectRemovedMessage};
 use rand::seq::IndexedRandom;
 use rand::RngExt;
 
@@ -264,7 +264,7 @@ pub fn handle_status_effect_removed(
         Option<&mut Absorption>,
         &mut Flags,
     )>,
-    mut messages: MessageReader<StatusEffectRemoved>,
+    mut messages: MessageReader<StatusEffectRemovedMessage>,
 ) {
     for message in messages.read() {
         if let Ok((mut attributes, mut health, absorption, mut flags)) =

--- a/examples/resource_pack.rs
+++ b/examples/resource_pack.rs
@@ -4,7 +4,7 @@ use chunkedge::entity::sheep::SheepEntityBundle;
 use chunkedge::message::SendMessage;
 use chunkedge::prelude::*;
 use chunkedge::protocol::packets::play::resource_pack_c2s::ResourcePackStatus;
-use chunkedge::resource_pack::ResourcePackStatusEvent;
+use chunkedge::resource_pack::ResourcePackStatusMessage;
 
 const SPAWN_Y: i32 = 64;
 
@@ -92,11 +92,11 @@ fn init_clients(
 
 fn prompt_on_punch(
     mut clients: Query<&mut Client>,
-    mut events: MessageReader<InteractEntityEvent>,
+    mut messages: MessageReader<InteractEntityMessage>,
 ) {
-    for event in events.read() {
-        if let Ok(mut client) = clients.get_mut(event.client) {
-            if event.interact == EntityInteraction::Attack {
+    for message in messages.read() {
+        if let Ok(mut client) = clients.get_mut(message.client) {
+            if message.interact == EntityInteraction::Attack {
                 client.set_resource_pack(
                     "https://github.com/ChunkEdge/ChunkEdge/raw/main/assets/example_pack.zip",
                     "d7c6108849fb190ec2a49f2d38b7f1f897d9ce9f",
@@ -110,11 +110,11 @@ fn prompt_on_punch(
 
 fn on_resource_pack_status(
     mut clients: Query<&mut Client>,
-    mut events: MessageReader<ResourcePackStatusEvent>,
+    mut messages: MessageReader<ResourcePackStatusMessage>,
 ) {
-    for (client, event) in events.read().map(|e| (e.client, e.status)) {
+    for (client, message) in messages.read().map(|e| (e.client, e.status)) {
         if let Ok(mut client) = clients.get_mut(client) {
-            match event.result {
+            match message.result {
                 ResourcePackStatus::Accepted => {
                     client.send_chat_message("Resource pack accepted.".color(Color::GREEN));
                 }

--- a/examples/world_border.rs
+++ b/examples/world_border.rs
@@ -3,7 +3,7 @@
 use bevy_app::App;
 use chunkedge::client::despawn_disconnected_clients;
 use chunkedge::inventory::HeldItem;
-use chunkedge::message::{ChatMessageEvent, SendMessage};
+use chunkedge::message::{ChatMessageMessage, SendMessage};
 use chunkedge::prelude::*;
 use chunkedge::world_border::*;
 
@@ -106,10 +106,10 @@ fn display_diameter(mut layers: Query<(&mut ChunkLayer, &WorldBorderLerp)>) {
 }
 
 fn border_controls(
-    mut events: MessageReader<ChatMessageEvent>,
+    mut messages: MessageReader<ChatMessageMessage>,
     mut layers: Query<(&mut WorldBorderCenter, &mut WorldBorderLerp), With<ChunkLayer>>,
 ) {
-    for x in events.read() {
+    for x in messages.read() {
         let parts: Vec<&str> = x.message.split(' ').collect();
         match parts[0] {
             "add" => {

--- a/examples/world_border.rs
+++ b/examples/world_border.rs
@@ -3,7 +3,7 @@
 use bevy_app::App;
 use chunkedge::client::despawn_disconnected_clients;
 use chunkedge::inventory::HeldItem;
-use chunkedge::message::{ChatMessageMessage, SendMessage};
+use chunkedge::message::{ChatReceivedMessage, SendMessage};
 use chunkedge::prelude::*;
 use chunkedge::world_border::*;
 
@@ -106,7 +106,7 @@ fn display_diameter(mut layers: Query<(&mut ChunkLayer, &WorldBorderLerp)>) {
 }
 
 fn border_controls(
-    mut messages: MessageReader<ChatMessageMessage>,
+    mut messages: MessageReader<ChatReceivedMessage>,
     mut layers: Query<(&mut WorldBorderCenter, &mut WorldBorderLerp), With<ChunkLayer>>,
 ) {
     for x in messages.read() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,9 @@ pub mod prelude {
     pub use bevy_ecs::prelude::*;
     #[cfg(feature = "advancement")]
     pub use chunkedge_advancement::{
-        event::AdvancementTabChangeEvent, Advancement, AdvancementBundle, AdvancementClientUpdate,
-        AdvancementCriteria, AdvancementDisplay, AdvancementFrameType, AdvancementRequirements,
+        message::AdvancementTabChangeMessage, Advancement, AdvancementBundle,
+        AdvancementClientUpdate, AdvancementCriteria, AdvancementDisplay, AdvancementFrameType,
+        AdvancementRequirements,
     };
     #[cfg(feature = "equipment")]
     pub use chunkedge_equipment::Equipment;
@@ -134,15 +135,15 @@ pub mod prelude {
     pub use chunkedge_player_list::{PlayerList, PlayerListEntry};
     pub use chunkedge_registry::biome::{Biome, BiomeId, BiomeRegistry};
     pub use chunkedge_registry::dimension_type::{DimensionType, DimensionTypeRegistry};
-    pub use chunkedge_server::action::{DiggingEvent, DiggingState};
+    pub use chunkedge_server::action::{DiggingMessage, DiggingState};
     pub use chunkedge_server::block::{BlockKind, BlockState, PropName, PropValue};
     pub use chunkedge_server::client::{
         despawn_disconnected_clients, Client, Ip, OldView, OldViewDistance, Properties, Username,
         View, ViewDistance, VisibleChunkLayer, VisibleEntityLayers,
     };
     pub use chunkedge_server::client_command::{
-        JumpWithHorseEvent, JumpWithHorseState, LeaveBedEvent, PlayerCommand, SneakEvent,
-        SneakState, SprintEvent, SprintState,
+        JumpWithHorseMessage, JumpWithHorseState, LeaveBedMessage, PlayerCommand, SneakMessage,
+        SneakState, SprintMessage, SprintState,
     };
     pub use chunkedge_server::entity::hitbox::{Hitbox, HitboxShape};
     pub use chunkedge_server::entity::{
@@ -153,7 +154,7 @@ pub mod prelude {
         EventLoopPostUpdate, EventLoopPreUpdate, EventLoopUpdate,
     };
     pub use chunkedge_server::ident::Ident;
-    pub use chunkedge_server::interact_entity::{EntityInteraction, InteractEntityEvent};
+    pub use chunkedge_server::interact_entity::{EntityInteraction, InteractEntityMessage};
     pub use chunkedge_server::layer::chunk::{
         Block, BlockRef, Chunk, ChunkLayer, LoadedChunk, UnloadedChunk,
     };

--- a/src/tests/inventory.rs
+++ b/src/tests/inventory.rs
@@ -7,7 +7,7 @@ use chunkedge_item::ItemComponent;
 use chunkedge_server::protocol::IntoTextComponent;
 
 use crate::inventory::{
-    convert_to_player_slot_id, ClickMode, ClientInventoryState, CursorItem, DropItemStackEvent,
+    convert_to_player_slot_id, ClickMode, ClientInventoryState, CursorItem, DropItemStackMessage,
     HeldItem, Inventory, InventoryKind, OpenInventory, SlotChange,
 };
 use crate::protocol::packets::play::{
@@ -1513,17 +1513,17 @@ mod dropping_items {
 
         assert_eq!(inventory.slot(36), &ItemStack::new(ItemKind::IronIngot, 2));
 
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
-        assert_eq!(events[0].from_slot, Some(36));
-        assert_eq!(events[0].stack, ItemStack::new(ItemKind::IronIngot, 1));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
+        assert_eq!(messages[0].from_slot, Some(36));
+        assert_eq!(messages[0].stack, ItemStack::new(ItemKind::IronIngot, 1));
 
         let sent_packets = helper.collect_received();
 
@@ -1571,15 +1571,15 @@ mod dropping_items {
             &ItemStack::new(ItemKind::IronIngot, 3)
         );
 
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        // when the inventory is read-only we do not emit a drop event
-        assert_eq!(events.len(), 0);
+        // when the inventory is read-only we do not emit a drop message
+        assert_eq!(messages.len(), 0);
 
         let sent_packets = helper.collect_received();
 
@@ -1626,15 +1626,15 @@ mod dropping_items {
             .get::<Inventory>(client)
             .expect("could not find inventory");
         assert_eq!(inventory.slot(36), &ItemStack::EMPTY);
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
-        assert_eq!(events[0].from_slot, Some(36));
-        assert_eq!(events[0].stack, ItemStack::new(ItemKind::IronIngot, 32));
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
+        assert_eq!(messages[0].from_slot, Some(36));
+        assert_eq!(messages[0].stack, ItemStack::new(ItemKind::IronIngot, 32));
     }
 
     #[test]
@@ -1678,14 +1678,14 @@ mod dropping_items {
             .expect("could not find inventory");
         // Inventory is read-only, item is not being dropped
         assert_eq!(inventory.slot(36), &ItemStack::new(ItemKind::IronIngot, 32));
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        // when the inventory is read-only we do not emit a drop event
-        assert_eq!(events.len(), 0);
+        // when the inventory is read-only we do not emit a drop message
+        assert_eq!(messages.len(), 0);
     }
 
     #[test]
@@ -1713,17 +1713,17 @@ mod dropping_items {
         app.update();
 
         // Make assertions
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events")
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages")
             .iter_current_update_messages()
             .collect::<Vec<_>>();
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
-        assert_eq!(events[0].from_slot, None);
-        assert_eq!(events[0].stack, ItemStack::new(ItemKind::IronIngot, 32));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
+        assert_eq!(messages[0].from_slot, None);
+        assert_eq!(messages[0].stack, ItemStack::new(ItemKind::IronIngot, 32));
     }
 
     #[test]
@@ -1774,18 +1774,18 @@ mod dropping_items {
 
         assert_eq!(cursor_item.0, ItemStack::EMPTY);
 
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
-        assert_eq!(events[0].from_slot, None);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
+        assert_eq!(messages[0].from_slot, None);
         assert_eq!(
-            events[0].stack,
+            messages[0].stack,
             ItemStack::new(ItemKind::IronIngot, 32).with_components(vec![
                 ItemComponent::CustomName("Droppable Iron".into_text_component()),
             ])
@@ -1836,13 +1836,13 @@ mod dropping_items {
             .expect("could not find client");
         assert_eq!(cursor_item.0, stack);
 
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events")
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages")
             .iter_current_update_messages()
             .collect::<Vec<_>>();
-        assert_eq!(events.len(), 0);
+        assert_eq!(messages.len(), 0);
 
         let sent_packets = helper.collect_received();
         sent_packets.assert_count::<ContainerSetContentS2c>(0);
@@ -1909,18 +1909,18 @@ mod dropping_items {
         app.update();
 
         // Make assertions
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
-        assert_eq!(events[0].from_slot, Some(40));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
+        assert_eq!(messages[0].from_slot, Some(40));
         assert_eq!(
-            events[0].stack,
+            messages[0].stack,
             ItemStack::new(ItemKind::IronIngot, 1).with_components(vec![
                 ItemComponent::CustomName("Custom Iron".into_text_component()),
                 ItemComponent::Lore(vec![
@@ -2009,15 +2009,15 @@ mod dropping_items {
             ])
         );
 
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        // when the inventory is read-only we do not emit a drop event
-        assert_eq!(events.len(), 0);
+        // when the inventory is read-only we do not emit a drop message
+        assert_eq!(messages.len(), 0);
     }
 
     #[test]
@@ -2074,18 +2074,18 @@ mod dropping_items {
         app.update();
 
         // Make assertions
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
-        assert_eq!(events[0].from_slot, Some(40));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
+        assert_eq!(messages[0].from_slot, Some(40));
         assert_eq!(
-            events[0].stack,
+            messages[0].stack,
             ItemStack::new(ItemKind::IronIngot, 32).with_components(vec![
                 ItemComponent::CustomName("Custom Iron".into_text_component()),
                 ItemComponent::Lore(vec![
@@ -2168,15 +2168,15 @@ mod dropping_items {
             ])
         );
 
-        let events = app
+        let messages = app
             .world_mut()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        // when the inventory is read-only we do not emit a drop event
-        assert_eq!(events.len(), 0);
+        // when the inventory is read-only we do not emit a drop message
+        assert_eq!(messages.len(), 0);
     }
 
     /// The item should be dropped successfully, if the player has an inventory
@@ -2247,27 +2247,27 @@ mod dropping_items {
         app.update();
 
         // Make assertions
-        let events = app
+        let messages = app
             .world()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
         let player_inventory = app
             .world()
             .get::<Inventory>(client)
             .expect("could not find inventory");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].client, client);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].client, client);
         assert_eq!(
-            events[0].from_slot,
+            messages[0].from_slot,
             Some(convert_to_player_slot_id(InventoryKind::Generic9x3, 50))
         );
 
         assert_eq!(
-            events[0].stack,
+            messages[0].stack,
             ItemStack::new(ItemKind::IronIngot, 1).with_components(vec![
                 ItemComponent::CustomName("Custom Iron".into_text_component()),
                 ItemComponent::Lore(vec![
@@ -2346,19 +2346,19 @@ mod dropping_items {
         app.update();
 
         // Make assertions
-        let events = app
+        let messages = app
             .world()
-            .get_resource::<Messages<DropItemStackEvent>>()
-            .expect("expected drop item stack events");
+            .get_resource::<Messages<DropItemStackMessage>>()
+            .expect("expected drop item stack messages");
 
         let player_inventory = app
             .world()
             .get::<Inventory>(client)
             .expect("could not find inventory");
 
-        let events = events.iter_current_update_messages().collect::<Vec<_>>();
-        // when the inventory is read-only we do not emit a drop event
-        assert_eq!(events.len(), 0);
+        let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
+        // when the inventory is read-only we do not emit a drop message
+        assert_eq!(messages.len(), 0);
 
         // Also make sure that the player inventory was not updated (as it is
         // read-only).
@@ -2432,26 +2432,26 @@ fn should_drop_item_stack_player_open_inventory_with_dropkey() {
     app.update();
 
     // Make assertions
-    let events = app
+    let messages = app
         .world()
-        .get_resource::<Messages<DropItemStackEvent>>()
-        .expect("expected drop item stack events");
+        .get_resource::<Messages<DropItemStackMessage>>()
+        .expect("expected drop item stack messages");
 
     let player_inventory = app
         .world()
         .get::<Inventory>(client)
         .expect("could not find inventory");
 
-    let events = events.iter_current_update_messages().collect::<Vec<_>>();
+    let messages = messages.iter_current_update_messages().collect::<Vec<_>>();
 
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].client, client);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].client, client);
     assert_eq!(
-        events[0].from_slot,
+        messages[0].from_slot,
         Some(convert_to_player_slot_id(InventoryKind::Generic9x3, 50))
     );
     assert_eq!(
-        events[0].stack,
+        messages[0].stack,
         ItemStack::new(ItemKind::IronIngot, 32).with_components(vec![
             ItemComponent::CustomName("Custom Iron".into_text_component()),
             ItemComponent::Lore(vec![

--- a/tools/playground/src/extras.rs
+++ b/tools/playground/src/extras.rs
@@ -7,11 +7,11 @@ use chunkedge::prelude::*;
 /// sneaking.
 pub(crate) fn toggle_gamemode_on_sneak(
     mut clients: Query<&mut GameMode>,
-    mut events: MessageReader<SneakEvent>,
+    mut messages: MessageReader<SneakMessage>,
 ) {
-    for event in events.read() {
-        if event.state == SneakState::Start {
-            if let Ok(mut mode) = clients.get_mut(event.client) {
+    for message in messages.read() {
+        if message.state == SneakState::Start {
+            if let Ok(mut mode) = clients.get_mut(message.client) {
                 *mode = match *mode {
                     GameMode::Survival => GameMode::Creative,
                     GameMode::Creative => GameMode::Survival,


### PR DESCRIPTION
# Objective

- Bevy has changed what previously were events to messages. Thus we need to refactor our events to be called messages to not be confusing with the new observable Bevy events.
 - Closes #27

# Solution

- Manually go over each occurence of `Event \{` and `event[a-z_]+\: Message` and renamed all of them using the rename tool in my editor.
 - Went over all remaining occurences of the word event and renamed where needed.
 - All Message structs are now suffixed with Message
 - All readers and writers which had 'event' in their name have been renamed to the same thing with 'message'
 - All docs referencing the old events are now referencing message 
