### PR TITLE
Migrate entity bundles to required components

### DIFF
--- a/benches/many_players.rs
+++ b/benches/many_players.rs
@@ -68,16 +68,17 @@ fn run_many_players(bencher: Bencher, client_count: usize, view_dist: u8, world_
 
         bundle.visible_chunk_layer.0 = layer;
         bundle.visible_entity_layers.0.insert(layer);
-        bundle.player.layer.0 = layer;
+        bundle.layer.0 = layer;
         bundle.view_distance.set(view_dist);
 
         let mut rng = rand::rng();
         let x = rng.random_range(-f64::from(world_size) * 16.0..=f64::from(world_size) * 16.0);
         let z = rng.random_range(-f64::from(world_size) * 16.0..=f64::from(world_size) * 16.0);
 
-        bundle.player.position.set(DVec3::new(x, 64.0, z));
-
-        let id = app.world_mut().spawn(bundle).id();
+        let id = app
+            .world_mut()
+            .spawn((bundle, Position::new(DVec3::new(x, 64.0, z))))
+            .id();
 
         clients.push((id, helper));
     }

--- a/crates/chunkedge_entity/build.rs
+++ b/crates/chunkedge_entity/build.rs
@@ -434,7 +434,7 @@ fn build_entities() -> anyhow::Result<TokenStream> {
     let mut system_names = vec![];
     let mut derived_system_names = vec![];
 
-    for (entity_name, entity) in entities.clone() {
+    for (entity_name, entity) in entities {
         let entity_name_ident = ident(&entity_name);
         let stripped_shouty_entity_name = strip_entity_suffix(&entity_name).to_shouty_snake_case();
         let stripped_shouty_entity_name_ident = ident(&stripped_shouty_entity_name);
@@ -443,8 +443,12 @@ fn build_entities() -> anyhow::Result<TokenStream> {
 
         let mut module_body = TokenStream::new();
 
-        if let Some(parent_name) = entity.parent {
-            let stripped_snake_parent_name = strip_entity_suffix(&parent_name).to_snake_case();
+        let mut requires: Vec<TokenStream> = vec![];
+
+        if let Some(parent_name) = &entity.parent {
+            let stripped_snake_parent_name = strip_entity_suffix(parent_name).to_snake_case();
+            let stripped_snake_parent_name_ident = ident(&stripped_snake_parent_name);
+            let pascal_parent_name_ident = ident(parent_name);
 
             let module_doc = format!(
                 "Parent class: \
@@ -454,6 +458,27 @@ fn build_entities() -> anyhow::Result<TokenStream> {
             module_body.extend([quote! {
                 #![doc = #module_doc]
             }]);
+
+            requires.push(quote! {
+                super::#stripped_snake_parent_name_ident::#pascal_parent_name_ident
+            });
+        } else {
+            requires.push(quote! {
+                super::EntityId,
+                super::UniqueId,
+                super::EntityLayerId,
+                super::OldEntityLayerId,
+                super::Position,
+                super::OldPosition,
+                super::Look,
+                super::HeadYaw,
+                super::OnGround,
+                super::Velocity,
+                super::EntityStatuses,
+                super::EntityAnimations,
+                super::ObjectData,
+                super::tracked_data::TrackedData
+            });
         }
 
         // Is this a concrete entity type?
@@ -478,168 +503,29 @@ fn build_entities() -> anyhow::Result<TokenStream> {
                 EntityKind::#stripped_shouty_entity_name_ident => #translation_key_expr,
             }]);
 
-            // Create bundle type.
-            let mut bundle_fields = TokenStream::new();
-            let mut bundle_init_fields = TokenStream::new();
+            requires.push(quote! {
+                super::EntityKind = super::EntityKind::#stripped_shouty_entity_name_ident
+            });
 
-            for marker_or_field in collect_bundle_fields(&entity_name, &entities) {
-                match marker_or_field {
-                    MarkerOrField::Marker { entity_name } => {
-                        let stripped_entity_name = strip_entity_suffix(entity_name);
+            if let Some(attributes) = &entity.attributes {
+                let mut attribute_default_values = TokenStream::new();
 
-                        let snake_entity_name_ident = ident(entity_name.to_snake_case());
-                        let stripped_snake_entity_name_ident =
-                            ident(stripped_entity_name.to_snake_case());
-                        let pascal_entity_name_ident = ident(entity_name.to_pascal_case());
-
-                        bundle_fields.extend([quote! {
-                            pub #snake_entity_name_ident: super::#stripped_snake_entity_name_ident::#pascal_entity_name_ident,
-                        }]);
-
-                        bundle_init_fields.extend([quote! {
-                            #snake_entity_name_ident: Default::default(),
-                        }]);
-
-                        match entity_name {
-                            "LivingEntity" => {
-                                bundle_fields.extend([quote! {
-                                    pub living_absorption: super::living::Absorption,
-                                }]);
-
-                                bundle_init_fields.extend([quote! {
-                                    living_absorption: Default::default(),
-                                }]);
-
-                                bundle_fields.extend([quote! {
-                                    pub living_attributes: super::attributes::EntityAttributes,
-                                }]);
-
-                                // Get the default values of the attributes.
-                                let mut attribute_default_values = TokenStream::new();
-
-                                if let Some(attributes) = &entity.attributes {
-                                    for attribute in attributes {
-                                        let name = ident(attribute.name.to_pascal_case());
-                                        let base_value = attribute.base_value;
-                                        attribute_default_values.extend([quote! {
-                                            .with_attribute_and_value(
-                                                super::EntityAttribute::#name,
-                                                #base_value,
-                                            )
-                                        }]);
-                                    }
-                                }
-
-                                bundle_init_fields.extend([quote! {
-                                    living_attributes: super::attributes::EntityAttributes::new() #attribute_default_values,
-                                }]);
-
-                                bundle_fields.extend([quote! {
-                                    pub living_attributes_tracker: super::attributes::TrackedEntityAttributes,
-                                }]);
-                                bundle_init_fields.extend([quote! {
-                                    living_attributes_tracker: Default::default(),
-                                }]);
-
-                                bundle_fields.extend([quote! {
-                                    pub living_active_status_effects: super::active_status_effects::ActiveStatusEffects,
-                                }]);
-                                bundle_init_fields.extend([quote! {
-                                    living_active_status_effects: Default::default(),
-                                }]);
-                            }
-                            "PlayerEntity" => {
-                                bundle_fields.extend([quote! {
-                                    pub player_food: super::player::Food,
-                                    pub player_saturation: super::player::Saturation,
-                                }]);
-
-                                bundle_init_fields.extend([quote! {
-                                    player_food: Default::default(),
-                                    player_saturation: Default::default(),
-                                }]);
-                            }
-                            _ => {}
-                        }
-                    }
-                    MarkerOrField::Field { entity_name, field } => {
-                        let snake_field_name = field.name.to_snake_case();
-                        let pascal_field_name = field.name.to_pascal_case();
-                        let pascal_field_name_ident = ident(&pascal_field_name);
-                        let stripped_entity_name = strip_entity_suffix(entity_name);
-                        let stripped_snake_entity_name = stripped_entity_name.to_snake_case();
-                        let stripped_snake_entity_name_ident = ident(&stripped_snake_entity_name);
-
-                        let field_name_ident =
-                            ident(format!("{stripped_snake_entity_name}_{snake_field_name}"));
-
-                        bundle_fields.extend([quote! {
-                            pub #field_name_ident: super::#stripped_snake_entity_name_ident::#pascal_field_name_ident,
-                        }]);
-
-                        bundle_init_fields.extend([quote! {
-                            #field_name_ident: Default::default(),
-                        }]);
-                    }
+                for attribute in attributes {
+                    let name = ident(attribute.name.to_pascal_case());
+                    let base_value = attribute.base_value;
+                    attribute_default_values.extend([quote! {
+                        .with_attribute_and_value(
+                            super::EntityAttribute::#name,
+                            #base_value,
+                        )
+                    }]);
                 }
+
+                requires.push(quote! {
+                    super::attributes::EntityAttributes =
+                        super::attributes::EntityAttributes::new() #attribute_default_values
+                });
             }
-
-            bundle_fields.extend([quote! {
-                pub kind: super::EntityKind,
-                pub id: super::EntityId,
-                pub uuid: super::UniqueId,
-                pub layer: super::EntityLayerId,
-                pub old_layer: super::OldEntityLayerId,
-                pub position: super::Position,
-                pub old_position: super::OldPosition,
-                pub look: super::Look,
-                pub head_yaw: super::HeadYaw,
-                pub on_ground: super::OnGround,
-                pub velocity: super::Velocity,
-                pub statuses: super::EntityStatuses,
-                pub animations: super::EntityAnimations,
-                pub object_data: super::ObjectData,
-                pub tracked_data: super::tracked_data::TrackedData,
-            }]);
-
-            bundle_init_fields.extend([quote! {
-                kind: super::EntityKind::#stripped_shouty_entity_name_ident,
-                id: Default::default(),
-                uuid: Default::default(),
-                layer: Default::default(),
-                old_layer: Default::default(),
-                position: Default::default(),
-                old_position: Default::default(),
-                look: Default::default(),
-                head_yaw: Default::default(),
-                on_ground: Default::default(),
-                velocity: Default::default(),
-                statuses: Default::default(),
-                animations: Default::default(),
-                object_data: Default::default(),
-                tracked_data: Default::default(),
-            }]);
-
-            let bundle_name_ident = ident(format!("{entity_name}Bundle"));
-            let bundle_doc = format!(
-                "The bundle of components for spawning `{stripped_snake_entity_name}` entities."
-            );
-
-            module_body.extend([quote! {
-                #[doc = #bundle_doc]
-                #[derive(bevy_ecs::bundle::Bundle, Debug)]
-                pub struct #bundle_name_ident {
-                    #bundle_fields
-                }
-
-                impl Default for #bundle_name_ident {
-                    fn default() -> Self {
-                        Self {
-                            #bundle_init_fields
-                        }
-                    }
-                }
-            }]);
         }
 
         for field in &entity.fields {
@@ -659,6 +545,8 @@ fn build_entities() -> anyhow::Result<TokenStream> {
                     }
                 }
             }]);
+
+            requires.push(quote!(#pascal_field_name_ident));
 
             let system_name_ident = ident(format!(
                 "update_{stripped_snake_entity_name}_{snake_field_name}"
@@ -694,11 +582,36 @@ fn build_entities() -> anyhow::Result<TokenStream> {
             }]);
         }
 
+        match entity_name.as_str() {
+            "LivingEntity" => {
+                requires.push(quote! {
+                    Absorption,
+                    super::attributes::EntityAttributes,
+                    super::attributes::TrackedEntityAttributes,
+                    super::active_status_effects::ActiveStatusEffects
+                });
+            }
+            "PlayerEntity" => {
+                requires.push(quote! {
+                    Food,
+                    Saturation
+                });
+            }
+            _ => {}
+        }
+
         let marker_doc = format!("Marker component for `{stripped_snake_entity_name}` entities.");
+
+        let require_attr = if requires.is_empty() {
+            quote!()
+        } else {
+            quote!(#[require(#(#requires),*)])
+        };
 
         module_body.extend([quote! {
             #[doc = #marker_doc]
             #[derive(bevy_ecs::component::Component, Copy, Clone, Default, Debug)]
+            #require_attr
             pub struct #entity_name_ident;
         }]);
 
@@ -868,42 +781,6 @@ fn build_entities() -> anyhow::Result<TokenStream> {
             )*
         }
     })
-}
-
-enum MarkerOrField<'a> {
-    Marker {
-        entity_name: &'a str,
-    },
-    Field {
-        entity_name: &'a str,
-        field: &'a Field,
-    },
-}
-
-fn collect_bundle_fields<'a>(
-    mut entity_name: &'a str,
-    entities: &'a Entities,
-) -> Vec<MarkerOrField<'a>> {
-    let mut res = vec![];
-
-    loop {
-        let e = &entities[entity_name];
-
-        res.push(MarkerOrField::Marker { entity_name });
-        res.extend(
-            e.fields
-                .iter()
-                .map(|field| MarkerOrField::Field { entity_name, field }),
-        );
-
-        if let Some(parent) = &e.parent {
-            entity_name = parent;
-        } else {
-            break;
-        }
-    }
-
-    res
 }
 
 fn strip_entity_suffix(string: &str) -> String {

--- a/crates/chunkedge_server/src/client.rs
+++ b/crates/chunkedge_server/src/client.rs
@@ -13,11 +13,11 @@ use bytes::{Bytes, BytesMut};
 use chunkedge_binary::Encode;
 use chunkedge_entity::attributes::{EntityAttributes, TrackedEntityAttributes};
 use chunkedge_entity::living::Health;
-use chunkedge_entity::player::{Food, PlayerEntityBundle, Saturation};
+use chunkedge_entity::player::{Food, PlayerEntity, Saturation};
 use chunkedge_entity::query::EntityInitQuery;
 use chunkedge_entity::tracked_data::TrackedData;
 use chunkedge_entity::{
-    ClearEntityChangesSet, EntityId, EntityStatus, OldPosition, Position, Velocity,
+    ClearEntityChangesSet, EntityId, EntityLayerId, EntityStatus, OldPosition, Position, Velocity,
 };
 use chunkedge_math::{DVec3, Vec3};
 use chunkedge_protocol::encode::{PacketEncoder, WritePacket};
@@ -146,7 +146,11 @@ pub struct ClientBundle {
     pub flying_speed: crate::abilities::FlyingSpeed,
     pub fov_modifier: crate::abilities::FovModifier,
     pub player_abilities_flags: crate::abilities::PlayerAbilitiesFlags,
-    pub player: PlayerEntityBundle,
+    pub player: PlayerEntity,
+    pub uuid: UniqueId,
+    pub layer: EntityLayerId,
+    pub player_model_parts: chunkedge_entity::player::PlayerModelParts,
+    pub main_arm: chunkedge_entity::player::MainArm,
 }
 
 impl ClientBundle {
@@ -194,15 +198,13 @@ impl ClientBundle {
             flying_speed: Default::default(),
             fov_modifier: Default::default(),
             player_abilities_flags: Default::default(),
-            player: PlayerEntityBundle {
-                uuid: UniqueId(args.uuid),
-                player_player_model_parts: chunkedge_entity::player::PlayerModelParts(u8::from(
-                    args.displayed_skin_parts,
-                )
-                    as i8),
-                player_main_arm: chunkedge_entity::player::MainArm(args.main_arm as i8),
-                ..Default::default()
-            },
+            player: PlayerEntity,
+            uuid: UniqueId(args.uuid),
+            layer: Default::default(),
+            player_model_parts: chunkedge_entity::player::PlayerModelParts(u8::from(
+                args.displayed_skin_parts,
+            ) as i8),
+            main_arm: chunkedge_entity::player::MainArm(args.main_arm as i8),
         }
     }
 }

--- a/crates/chunkedge_server/src/client.rs
+++ b/crates/chunkedge_server/src/client.rs
@@ -13,7 +13,7 @@ use bytes::{Bytes, BytesMut};
 use chunkedge_binary::Encode;
 use chunkedge_entity::attributes::{EntityAttributes, TrackedEntityAttributes};
 use chunkedge_entity::living::Health;
-use chunkedge_entity::player::{Food, PlayerEntity, Saturation};
+use chunkedge_entity::player::{Food, MainArm as PlayerMainArm, PlayerEntity, PlayerModelParts, Saturation};
 use chunkedge_entity::query::EntityInitQuery;
 use chunkedge_entity::tracked_data::TrackedData;
 use chunkedge_entity::{
@@ -149,8 +149,8 @@ pub struct ClientBundle {
     pub player: PlayerEntity,
     pub uuid: UniqueId,
     pub layer: EntityLayerId,
-    pub player_model_parts: chunkedge_entity::player::PlayerModelParts,
-    pub main_arm: chunkedge_entity::player::MainArm,
+    pub player_model_parts: PlayerModelParts,
+    pub main_arm: PlayerMainArm,
 }
 
 impl ClientBundle {
@@ -201,10 +201,10 @@ impl ClientBundle {
             player: PlayerEntity,
             uuid: UniqueId(args.uuid),
             layer: Default::default(),
-            player_model_parts: chunkedge_entity::player::PlayerModelParts(u8::from(
+            player_model_parts: PlayerModelParts(u8::from(
                 args.displayed_skin_parts,
             ) as i8),
-            main_arm: chunkedge_entity::player::MainArm(args.main_arm as i8),
+            main_arm: PlayerMainArm(args.main_arm as i8),
         }
     }
 }

--- a/crates/chunkedge_server/src/client.rs
+++ b/crates/chunkedge_server/src/client.rs
@@ -13,7 +13,9 @@ use bytes::{Bytes, BytesMut};
 use chunkedge_binary::Encode;
 use chunkedge_entity::attributes::{EntityAttributes, TrackedEntityAttributes};
 use chunkedge_entity::living::Health;
-use chunkedge_entity::player::{Food, MainArm as PlayerMainArm, PlayerEntity, PlayerModelParts, Saturation};
+use chunkedge_entity::player::{
+    Food, MainArm as PlayerMainArm, PlayerEntity, PlayerModelParts, Saturation,
+};
 use chunkedge_entity::query::EntityInitQuery;
 use chunkedge_entity::tracked_data::TrackedData;
 use chunkedge_entity::{
@@ -201,9 +203,7 @@ impl ClientBundle {
             player: PlayerEntity,
             uuid: UniqueId(args.uuid),
             layer: Default::default(),
-            player_model_parts: PlayerModelParts(u8::from(
-                args.displayed_skin_parts,
-            ) as i8),
+            player_model_parts: PlayerModelParts(u8::from(args.displayed_skin_parts) as i8),
             main_arm: PlayerMainArm(args.main_arm as i8),
         }
     }

--- a/examples/boss_bar.rs
+++ b/examples/boss_bar.rs
@@ -5,7 +5,7 @@ use chunkedge_boss_bar::{
     BossBarBundle, BossBarColor, BossBarDivision, BossBarFlags, BossBarHealth, BossBarStyle,
     BossBarTitle,
 };
-use chunkedge_server::entity::cow::CowEntityBundle;
+use chunkedge_server::entity::cow::CowEntity;
 use chunkedge_server::message::ChatReceivedMessage;
 use chunkedge_text::color::NamedColor;
 use rand::seq::IndexedRandom;
@@ -61,11 +61,9 @@ fn setup(
     ));
 
     commands.spawn((
-        CowEntityBundle {
-            position: Position::new([0.0, f64::from(SPAWN_Y) + 1.0, 0.0]),
-            layer: EntityLayerId(layer_id),
-            ..Default::default()
-        },
+        CowEntity,
+        Position::new([0.0, f64::from(SPAWN_Y) + 1.0, 0.0]),
+        EntityLayerId(layer_id),
         BossBarTitle("Louis XVI".color(NamedColor::Red)),
         BossBarHealth(0.5),
         BossBarStyle {

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -3,12 +3,11 @@
 use std::f64::consts::TAU;
 
 use chunkedge::abilities::{PlayerStartFlyingMessage, PlayerStopFlyingMessage};
+use chunkedge::entity::cow::CowEntity;
 use chunkedge::math::{DQuat, EulerRot};
 use chunkedge::message::SendMessage;
 use chunkedge::prelude::*;
 use chunkedge_text::color::NamedColor;
-
-type SpherePartBundle = chunkedge::entity::cow::CowEntityBundle;
 
 const SPHERE_CENTER: DVec3 = DVec3::new(0.5, SPAWN_POS.y as f64 + 2.0, 0.5);
 const SPHERE_AMOUNT: usize = 200;
@@ -56,15 +55,8 @@ fn setup(
 
     let layer_id = commands.spawn(layer).id();
 
-    commands.spawn_batch([0; SPHERE_AMOUNT].map(|_| {
-        (
-            SpherePartBundle {
-                layer: EntityLayerId(layer_id),
-                ..Default::default()
-            },
-            SpherePart,
-        )
-    }));
+    commands
+        .spawn_batch([0; SPHERE_AMOUNT].map(|_| (CowEntity, EntityLayerId(layer_id), SpherePart)));
 }
 
 fn init_clients(

--- a/examples/cow_sphere.rs
+++ b/examples/cow_sphere.rs
@@ -18,7 +18,7 @@ const SPHERE_FREQ: f64 = 0.5;
 const SPAWN_POS: BlockPos = BlockPos::new(0, 100, -16);
 
 /// Marker component for entities that are part of the sphere.
-#[derive(Component)]
+#[derive(Component, Copy, Clone)]
 struct SpherePart;
 
 fn main() {
@@ -55,8 +55,7 @@ fn setup(
 
     let layer_id = commands.spawn(layer).id();
 
-    commands
-        .spawn_batch([0; SPHERE_AMOUNT].map(|_| (CowEntity, EntityLayerId(layer_id), SpherePart)));
+    commands.spawn_batch([(CowEntity, EntityLayerId(layer_id), SpherePart); SPHERE_AMOUNT]);
 }
 
 fn init_clients(

--- a/examples/ctf.rs
+++ b/examples/ctf.rs
@@ -3,11 +3,11 @@
 use std::collections::HashMap;
 
 use bevy_ecs::query::QueryData;
-use chunkedge::entity::cow::CowEntityBundle;
+use chunkedge::entity::cow::CowEntity;
 use chunkedge::entity::entity::Flags;
 use chunkedge::entity::living::Health;
-use chunkedge::entity::pig::PigEntityBundle;
-use chunkedge::entity::player::PlayerEntityBundle;
+use chunkedge::entity::pig::PigEntity;
+use chunkedge::entity::player::PlayerEntity;
 use chunkedge::entity::{EntityAnimations, EntityStatuses, OnGround, Velocity};
 use chunkedge::interact_block::InteractBlockMessage;
 use chunkedge::inventory::HeldItem;
@@ -141,20 +141,20 @@ fn setup(
     // add some debug entities to the ctf entity layers
     let mut flags = Flags::default();
     flags.set_glowing(true);
-    let mut pig = commands.spawn(PigEntityBundle {
-        layer: EntityLayerId(ctf_team_layers.friendly_layers[&Team::Red]),
-        position: Position([-30.0, 65.0, 2.0].into()),
-        entity_flags: flags.clone(),
-        ..Default::default()
-    });
+    let mut pig = commands.spawn((
+        PigEntity,
+        EntityLayerId(ctf_team_layers.friendly_layers[&Team::Red]),
+        Position([-30.0, 65.0, 2.0].into()),
+        flags.clone(),
+    ));
     pig.insert(Team::Red);
 
-    let mut cow = commands.spawn(CowEntityBundle {
-        layer: EntityLayerId(ctf_team_layers.friendly_layers[&Team::Blue]),
-        position: Position([30.0, 65.0, 2.0].into()),
-        entity_flags: flags,
-        ..Default::default()
-    });
+    let mut cow = commands.spawn((
+        CowEntity,
+        EntityLayerId(ctf_team_layers.friendly_layers[&Team::Blue]),
+        Position([30.0, 65.0, 2.0].into()),
+        flags,
+    ));
     cow.insert(Team::Blue);
 
     commands.insert_resource(ctf_team_layers);
@@ -657,22 +657,18 @@ fn do_team_selector_portals(
             // Copy the player entity to the friendly layer, and make them glow.
             let mut flags = Flags::default();
             flags.set_glowing(true);
-            let mut player_glowing = commands.spawn(PlayerEntityBundle {
-                layer: EntityLayerId(friendly_layer),
-                uuid: *unique_id,
-                entity_flags: flags,
-                position: *pos,
-                ..Default::default()
-            });
+            let mut player_glowing = commands.spawn((
+                PlayerEntity,
+                EntityLayerId(friendly_layer),
+                *unique_id,
+                flags,
+                *pos,
+            ));
             player_glowing.insert(ClonedEntity(player));
 
             let enemy_layer = ctf_layers.enemy_layers[&team];
-            let mut player_enemy = commands.spawn(PlayerEntityBundle {
-                layer: EntityLayerId(enemy_layer),
-                uuid: *unique_id,
-                position: *pos,
-                ..Default::default()
-            });
+            let mut player_enemy =
+                commands.spawn((PlayerEntity, EntityLayerId(enemy_layer), *unique_id, *pos));
             player_enemy.insert(ClonedEntity(player));
         }
     }

--- a/examples/custom_npc.rs
+++ b/examples/custom_npc.rs
@@ -1,4 +1,4 @@
-use chunkedge::entity::player::PlayerEntityBundle;
+use chunkedge::entity::player::PlayerEntity;
 use chunkedge::player_list::{DisplayName, Listed, PlayerListEntryBundle};
 use chunkedge::prelude::*;
 use chunkedge::text::IntoText;
@@ -46,14 +46,14 @@ fn setup(
 
     let npc_id = UniqueId::default();
 
-    commands.spawn(PlayerEntityBundle {
-        layer: EntityLayerId(layer_id),
-        uuid: npc_id,
-        position: Position::new((0.0, f64::from(SPAWN_Y) + 1.0, 6.0)),
-        look: Look::new(180.0, 0.0),
-        head_yaw: HeadYaw(180.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        PlayerEntity,
+        EntityLayerId(layer_id),
+        npc_id,
+        Position::new((0.0, f64::from(SPAWN_Y) + 1.0, 6.0)),
+        Look::new(180.0, 0.0),
+        HeadYaw(180.0),
+    ));
 
     // In order for the player entity to be visible to other players, there must
     // be an entry in the player list.

--- a/examples/entity_hitbox.rs
+++ b/examples/entity_hitbox.rs
@@ -4,12 +4,12 @@ use std::collections::HashMap;
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use chunkedge::entity::hoglin::HoglinEntityBundle;
-use chunkedge::entity::pig::PigEntityBundle;
-use chunkedge::entity::sheep::SheepEntityBundle;
-use chunkedge::entity::warden::WardenEntityBundle;
-use chunkedge::entity::zombie::ZombieEntityBundle;
-use chunkedge::entity::zombie_horse::ZombieHorseEntityBundle;
+use chunkedge::entity::hoglin::HoglinEntity;
+use chunkedge::entity::pig::PigEntity;
+use chunkedge::entity::sheep::SheepEntity;
+use chunkedge::entity::warden::WardenEntity;
+use chunkedge::entity::zombie::ZombieEntity;
+use chunkedge::entity::zombie_horse::ZombieHorseEntity;
 use chunkedge::entity::{entity, Pose};
 use chunkedge::prelude::*;
 use entity::NameVisible;
@@ -97,49 +97,19 @@ fn spawn_entity(
         let layer = *layer;
 
         match rand::rng().random_range(0..7) {
-            0 => commands.spawn(SheepEntityBundle {
+            0 => commands.spawn((SheepEntity, position, layer, NameVisible(true))),
+            1 => commands.spawn((PigEntity, position, layer, NameVisible(true))),
+            2 => commands.spawn((ZombieEntity, position, layer, NameVisible(true))),
+            3 => commands.spawn((ZombieHorseEntity, position, layer, NameVisible(true))),
+            4 => commands.spawn((
+                WardenEntity,
                 position,
                 layer,
-                entity_name_visible: NameVisible(true),
-                ..Default::default()
-            }),
-            1 => commands.spawn(PigEntityBundle {
-                position,
-                layer,
-                entity_name_visible: NameVisible(true),
-                ..Default::default()
-            }),
-            2 => commands.spawn(ZombieEntityBundle {
-                position,
-                layer,
-                entity_name_visible: NameVisible(true),
-                ..Default::default()
-            }),
-            3 => commands.spawn(ZombieHorseEntityBundle {
-                position,
-                layer,
-                entity_name_visible: NameVisible(true),
-                ..Default::default()
-            }),
-            4 => commands.spawn(WardenEntityBundle {
-                position,
-                layer,
-                entity_name_visible: NameVisible(true),
-                entity_pose: entity::Pose(Pose::Digging),
-                ..Default::default()
-            }),
-            5 => commands.spawn(WardenEntityBundle {
-                position,
-                layer,
-                entity_name_visible: NameVisible(true),
-                ..Default::default()
-            }),
-            6 => commands.spawn(HoglinEntityBundle {
-                position,
-                layer,
-                entity_name_visible: NameVisible(true),
-                ..Default::default()
-            }),
+                NameVisible(true),
+                entity::Pose(Pose::Digging),
+            )),
+            5 => commands.spawn((WardenEntity, position, layer, NameVisible(true))),
+            6 => commands.spawn((HoglinEntity, position, layer, NameVisible(true))),
             _ => unreachable!(),
         };
     }

--- a/examples/entity_metadata.rs
+++ b/examples/entity_metadata.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use chunkedge::entity::breeze::BreezeEntityBundle;
-use chunkedge::entity::cat::{self, CatEntityBundle};
-use chunkedge::entity::enderman::{self, EndermanEntityBundle};
-use chunkedge::entity::frog::FrogEntityBundle;
-use chunkedge::entity::painting::{self, PaintingEntityBundle};
-use chunkedge::entity::player::PlayerEntityBundle;
-use chunkedge::entity::warden::WardenEntityBundle;
-use chunkedge::entity::zombie::ZombieEntityBundle;
+use chunkedge::entity::breeze::BreezeEntity;
+use chunkedge::entity::cat::{self, CatEntity};
+use chunkedge::entity::enderman::{self, EndermanEntity};
+use chunkedge::entity::frog::FrogEntity;
+use chunkedge::entity::painting::{self, PaintingEntity};
+use chunkedge::entity::player::PlayerEntity;
+use chunkedge::entity::warden::WardenEntity;
+use chunkedge::entity::zombie::ZombieEntity;
 use chunkedge::entity::{
     entity, CatKind, EntityLayerId, ObjectData, OnGround, PaintingKind, PaintingVariantDefinition,
     Pose,
@@ -80,26 +80,26 @@ impl MobDemo {
         layer: EntityLayerId,
         pose: Pose,
     ) -> Entity {
-        macro_rules! spawn_bundle {
-            ($bundle:ident) => {
+        macro_rules! spawn_entity {
+            ($marker:ident) => {
                 commands
-                    .spawn($bundle {
+                    .spawn((
+                        $marker,
                         position,
                         layer,
-                        look: Look::new(DEMO_ENTITY_YAW, 0.0),
-                        head_yaw: HeadYaw(DEMO_ENTITY_YAW),
-                        entity_pose: entity::Pose(pose),
-                        ..Default::default()
-                    })
+                        Look::new(DEMO_ENTITY_YAW, 0.0),
+                        HeadYaw(DEMO_ENTITY_YAW),
+                        entity::Pose(pose),
+                    ))
                     .id()
             };
         }
 
         match self {
-            Self::Breeze => spawn_bundle!(BreezeEntityBundle),
-            Self::Frog => spawn_bundle!(FrogEntityBundle),
-            Self::Warden => spawn_bundle!(WardenEntityBundle),
-            Self::Zombie => spawn_bundle!(ZombieEntityBundle),
+            Self::Breeze => spawn_entity!(BreezeEntity),
+            Self::Frog => spawn_entity!(FrogEntity),
+            Self::Warden => spawn_entity!(WardenEntity),
+            Self::Zombie => spawn_entity!(ZombieEntity),
         }
     }
 }
@@ -416,14 +416,14 @@ fn spawn_cat_variant(
     variant: CatKind,
 ) -> Entity {
     commands
-        .spawn(CatEntityBundle {
+        .spawn((
+            CatEntity,
             layer,
             position,
-            look: Look::new(DEMO_ENTITY_YAW, 0.0),
-            head_yaw: HeadYaw(DEMO_ENTITY_YAW),
-            cat_cat_variant: cat::CatVariant(variant),
-            ..Default::default()
-        })
+            Look::new(DEMO_ENTITY_YAW, 0.0),
+            HeadYaw(DEMO_ENTITY_YAW),
+            cat::CatVariant(variant),
+        ))
         .id()
 }
 
@@ -434,13 +434,13 @@ fn spawn_painting_variant(
     variant: IdOr<PaintingVariantDefinition>,
 ) -> Entity {
     commands
-        .spawn(PaintingEntityBundle {
+        .spawn((
+            PaintingEntity,
             layer,
-            position: Position::new((position.0.x, position.0.y + 1.0, position.0.z)),
-            object_data: ObjectData(2),
-            painting_variant: painting::Variant(variant),
-            ..Default::default()
-        })
+            Position::new((position.0.x, position.0.y + 1.0, position.0.z)),
+            ObjectData(2),
+            painting::Variant(variant),
+        ))
         .id()
 }
 
@@ -458,14 +458,14 @@ fn spawn_enderman(
     }
 
     commands
-        .spawn(EndermanEntityBundle {
+        .spawn((
+            EndermanEntity,
             layer,
             position,
-            look: Look::new(DEMO_ENTITY_YAW, 0.0),
-            head_yaw: HeadYaw(DEMO_ENTITY_YAW),
-            enderman_carried_block: enderman::CarriedBlock(carried_block),
-            ..Default::default()
-        })
+            Look::new(DEMO_ENTITY_YAW, 0.0),
+            HeadYaw(DEMO_ENTITY_YAW),
+            enderman::CarriedBlock(carried_block),
+        ))
         .id()
 }
 
@@ -591,14 +591,14 @@ fn spawn_player_npc(
     let npc = station.player_npc.unwrap();
 
     commands
-        .spawn(PlayerEntityBundle {
-            uuid: npc.uuid,
+        .spawn((
+            PlayerEntity,
+            npc.uuid,
             layer,
-            position: station.spawn_pos,
-            look: Look::new(DEMO_ENTITY_YAW, 0.0),
-            head_yaw: HeadYaw(DEMO_ENTITY_YAW),
-            entity_pose: entity::Pose(pose),
-            ..Default::default()
-        })
+            station.spawn_pos,
+            Look::new(DEMO_ENTITY_YAW, 0.0),
+            HeadYaw(DEMO_ENTITY_YAW),
+            entity::Pose(pose),
+        ))
         .id()
 }

--- a/examples/equipment.rs
+++ b/examples/equipment.rs
@@ -2,8 +2,8 @@
 
 const SPAWN_Y: i32 = 64;
 
-use chunkedge::entity::armor_stand::ArmorStandEntityBundle;
-use chunkedge::entity::zombie::ZombieEntityBundle;
+use chunkedge::entity::armor_stand::ArmorStandEntity;
+use chunkedge::entity::zombie::ZombieEntity;
 use chunkedge::equipment::{EquipmentInteractionBroadcast, EquipmentInventorySync};
 use chunkedge::prelude::*;
 use chunkedge::protocol::packets::play::set_equipment_s2c::EquipmentSlot;
@@ -49,17 +49,17 @@ fn setup(
 
     let layer_id = commands.spawn(layer).id();
 
-    commands.spawn(ZombieEntityBundle {
-        position: Position::new(DVec3::new(0.0, f64::from(SPAWN_Y) + 1.0, 0.0)),
-        layer: EntityLayerId(layer_id),
-        ..Default::default()
-    });
+    commands.spawn((
+        ZombieEntity,
+        Position::new(DVec3::new(0.0, f64::from(SPAWN_Y) + 1.0, 0.0)),
+        EntityLayerId(layer_id),
+    ));
 
-    commands.spawn(ArmorStandEntityBundle {
-        position: Position::new(DVec3::new(1.0, f64::from(SPAWN_Y) + 1.0, 0.0)),
-        layer: EntityLayerId(layer_id),
-        ..Default::default()
-    });
+    commands.spawn((
+        ArmorStandEntity,
+        Position::new(DVec3::new(1.0, f64::from(SPAWN_Y) + 1.0, 0.0)),
+        EntityLayerId(layer_id),
+    ));
 }
 
 fn init_clients(

--- a/examples/passenger.rs
+++ b/examples/passenger.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-use chunkedge::prelude::*;
-
-type VehicleBundle = chunkedge::entity::pig::PigEntityBundle;
-type CowBundle = chunkedge::entity::cow::CowEntityBundle;
+use chunkedge::{entity::cow::CowEntity, entity::pig::PigEntity, prelude::*};
 
 const SPAWN_Y: i32 = 64;
 const VEHICLE_POS: [f64; 3] = [0.0, SPAWN_Y as f64 + 1.0, 3.0];
@@ -59,32 +56,26 @@ fn setup(
     let layer_id = commands.spawn(layer).id();
 
     commands.spawn((
-        VehicleBundle {
-            layer: EntityLayerId(layer_id),
-            position: Position::new(VEHICLE_POS),
-            ..Default::default()
-        },
+        PigEntity,
+        EntityLayerId(layer_id),
+        Position::new(VEHICLE_POS),
         Vehicle,
         Orbit(VEHICLE_POS.into()),
     ));
 
     let cow = commands
         .spawn((
-            CowBundle {
-                layer: EntityLayerId(layer_id),
-                position: Position::new(COW_POS),
-                ..Default::default()
-            },
+            CowEntity,
+            EntityLayerId(layer_id),
+            Position::new(COW_POS),
             Orbit(COW_POS.into()),
         ))
         .id();
 
     commands.spawn((
-        CowBundle {
-            layer: EntityLayerId(layer_id),
-            position: Position::new(COW_POS),
-            ..Default::default()
-        },
+        CowEntity,
+        EntityLayerId(layer_id),
+        Position::new(COW_POS),
         Riding(cow),
     ));
 }

--- a/examples/resource_pack.rs
+++ b/examples/resource_pack.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::type_complexity)]
 
-use chunkedge::entity::sheep::SheepEntityBundle;
+use chunkedge::entity::sheep::SheepEntity;
 use chunkedge::message::SendMessage;
 use chunkedge::prelude::*;
 use chunkedge::protocol::packets::play::resource_pack_c2s::ResourcePackStatus;
@@ -46,13 +46,13 @@ fn setup(
 
     let layer_ent = commands.spawn(layer).id();
 
-    commands.spawn(SheepEntityBundle {
-        layer: EntityLayerId(layer_ent),
-        position: Position::new([0.0, f64::from(SPAWN_Y) + 1.0, 2.0]),
-        look: Look::new(180.0, 0.0),
-        head_yaw: HeadYaw(180.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        SheepEntity,
+        EntityLayerId(layer_ent),
+        Position::new([0.0, f64::from(SPAWN_Y) + 1.0, 2.0]),
+        Look::new(180.0, 0.0),
+        HeadYaw(180.0),
+    ));
 }
 
 fn init_clients(

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -59,7 +59,7 @@ impl ScenarioSingleClient {
         let layer = app.world_mut().spawn((chunk_layer, entity_layer)).id();
 
         let (mut client, helper) = create_mock_client("test");
-        client.player.layer.0 = layer;
+        client.layer.0 = layer;
         client.visible_chunk_layer.0 = layer;
         client.visible_entity_layers.0.insert(layer);
         let client = app.world_mut().spawn(client).id();

--- a/src/tests/client.rs
+++ b/src/tests/client.rs
@@ -30,7 +30,7 @@ fn client_teleport_and_move() {
 
     let (mut bundle, mut helper_2) = create_mock_client("other");
 
-    bundle.player.layer.0 = layer_ent;
+    bundle.layer.0 = layer_ent;
     bundle.visible_chunk_layer.0 = layer_ent;
     bundle.visible_entity_layers.0.insert(layer_ent);
 

--- a/src/tests/equipment.rs
+++ b/src/tests/equipment.rs
@@ -2,9 +2,9 @@ use chunkedge_equipment::{Equipment, EquipmentInventorySync};
 use chunkedge_inventory::player_inventory::PlayerInventory;
 use chunkedge_inventory::{ClickMode, ClientInventoryState, Inventory};
 use chunkedge_item::HashedItemStack;
-use chunkedge_server::entity::armor_stand::ArmorStandEntityBundle;
-use chunkedge_server::entity::item::ItemEntityBundle;
-use chunkedge_server::entity::zombie::ZombieEntityBundle;
+use chunkedge_server::entity::armor_stand::ArmorStandEntity;
+use chunkedge_server::entity::item::ItemEntity;
+use chunkedge_server::entity::zombie::ZombieEntity;
 use chunkedge_server::entity::{EntityLayerId, Position};
 use chunkedge_server::math::DVec3;
 use chunkedge_server::protocol::packets::play::container_click_c2s::HashedSlotChange;
@@ -57,10 +57,7 @@ fn test_multiple_entities() {
     app.update();
     helper.clear_received();
 
-    let zombie_bundle = ZombieEntityBundle {
-        layer: EntityLayerId(layer),
-        ..Default::default()
-    };
+    let zombie_bundle = (ZombieEntity, EntityLayerId(layer));
 
     let zombie = app.world_mut().spawn(zombie_bundle).id();
 
@@ -111,11 +108,11 @@ fn test_update_on_load_entity() {
     app.update();
     helper.clear_received();
 
-    let zombie_bundle = ZombieEntityBundle {
-        layer: EntityLayerId(layer),
-        position: Position::new(DVec3::new(1000.0, 0.0, 1000.0)),
-        ..Default::default()
-    };
+    let zombie_bundle = (
+        ZombieEntity,
+        EntityLayerId(layer),
+        Position::new(DVec3::new(1000.0, 0.0, 1000.0)),
+    );
 
     let zombie = app
         .world_mut()
@@ -171,11 +168,11 @@ fn test_skip_update_for_empty_equipment() {
     app.update();
     helper.clear_received();
 
-    let zombie_bundle = ZombieEntityBundle {
-        layer: EntityLayerId(layer),
-        position: Position::new(DVec3::new(1000.0, 0.0, 1000.0)),
-        ..Default::default()
-    };
+    let zombie_bundle = (
+        ZombieEntity,
+        EntityLayerId(layer),
+        Position::new(DVec3::new(1000.0, 0.0, 1000.0)),
+    );
 
     app.world_mut()
         .spawn(zombie_bundle)
@@ -219,20 +216,11 @@ fn test_ensure_living_entities_only() {
     app.update();
     helper.clear_received();
 
-    let zombie_bundle = ZombieEntityBundle {
-        layer: EntityLayerId(layer),
-        ..Default::default()
-    };
+    let zombie_bundle = (ZombieEntity, EntityLayerId(layer));
 
-    let armor_stand_bundle = ArmorStandEntityBundle {
-        layer: EntityLayerId(layer),
-        ..Default::default()
-    };
+    let armor_stand_bundle = (ArmorStandEntity, EntityLayerId(layer));
 
-    let item_bundle = ItemEntityBundle {
-        layer: EntityLayerId(layer),
-        ..Default::default()
-    };
+    let item_bundle = (ItemEntity, EntityLayerId(layer));
 
     let zombie = app.world_mut().spawn(zombie_bundle).id();
 

--- a/src/tests/layer.rs
+++ b/src/tests/layer.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use bevy_ecs::world::EntityWorldMut;
 
 use crate::client::{ViewDistance, VisibleEntityLayers};
-use crate::entity::cow::CowEntityBundle;
+use crate::entity::cow::CowEntity;
 use crate::entity::{EntityLayerId, Position};
 use crate::layer::chunk::UnloadedChunk;
 use crate::layer::{ChunkLayer, EntityLayer};
@@ -237,20 +237,11 @@ fn entity_layer_switching() {
 
     // Spawn three entities and put them all on the main layer to start.
 
-    let e1 = CowEntityBundle {
-        layer: EntityLayerId(l1),
-        ..Default::default()
-    };
+    let e1 = (CowEntity, EntityLayerId(l1));
 
-    let e2 = CowEntityBundle {
-        layer: EntityLayerId(l1),
-        ..Default::default()
-    };
+    let e2 = (CowEntity, EntityLayerId(l1));
 
-    let e3 = CowEntityBundle {
-        layer: EntityLayerId(l1),
-        ..Default::default()
-    };
+    let e3 = (CowEntity, EntityLayerId(l1));
 
     let e1 = app.world_mut().spawn(e1).id();
     let _e2 = app.world_mut().spawn(e2).id();
@@ -346,11 +337,11 @@ fn chunk_entity_spawn_despawn() {
     // Put an entity in the new chunk.
     let cow_ent = app
         .world_mut()
-        .spawn(CowEntityBundle {
-            position: Position::new([8.0, 0.0, 8.0]),
-            layer: EntityLayerId(layer_ent),
-            ..Default::default()
-        })
+        .spawn((
+            CowEntity,
+            Position::new([8.0, 0.0, 8.0]),
+            EntityLayerId(layer_ent),
+        ))
         .id();
 
     app.update();

--- a/src/tests/passenger.rs
+++ b/src/tests/passenger.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use chunkedge_server::entity::pig::PigEntityBundle;
+use chunkedge_server::entity::pig::PigEntity;
 use chunkedge_server::entity::{EntityId, EntityLayerId, Position};
 use chunkedge_server::interact_entity::{EntityInteraction, InteractEntityMessage};
 use chunkedge_server::passenger::{Passengers, Riding};
@@ -23,11 +23,11 @@ fn passengers_broadcast_on_mount_and_dismount() {
 
     let vehicle = app
         .world_mut()
-        .spawn(PigEntityBundle {
-            layer: EntityLayerId(layer),
-            position: Position::new([0.0, 64.0, 0.0]),
-            ..Default::default()
-        })
+        .spawn((
+            PigEntity,
+            EntityLayerId(layer),
+            Position::new([0.0, 64.0, 0.0]),
+        ))
         .id();
 
     app.update();
@@ -88,19 +88,11 @@ fn passengers_sent_when_vehicle_enters_view() {
 
     let vehicle = app
         .world_mut()
-        .spawn(PigEntityBundle {
-            layer: EntityLayerId(layer),
-            position: Position::new(far),
-            ..Default::default()
-        })
+        .spawn((PigEntity, EntityLayerId(layer), Position::new(far)))
         .id();
     let rider = app
         .world_mut()
-        .spawn(PigEntityBundle {
-            layer: EntityLayerId(layer),
-            position: Position::new(far),
-            ..Default::default()
-        })
+        .spawn((PigEntity, EntityLayerId(layer), Position::new(far)))
         .id();
     app.world_mut().entity_mut(rider).insert(Riding(vehicle));
 
@@ -174,11 +166,9 @@ fn right_click_interaction_mounts_the_client() {
     let vehicle = app
         .world_mut()
         .spawn((
-            PigEntityBundle {
-                layer: EntityLayerId(layer),
-                position: Position::new([0.0, 64.0, 0.0]),
-                ..Default::default()
-            },
+            PigEntity,
+            EntityLayerId(layer),
+            Position::new([0.0, 64.0, 0.0]),
             Vehicle,
         ))
         .id();

--- a/src/tests/player_list.rs
+++ b/src/tests/player_list.rs
@@ -34,7 +34,7 @@ fn player_list_arrives_before_player_spawn() {
     };
 
     let (mut client_2, mut client_helper_2) = create_mock_client("test_2");
-    client_2.player.layer.0 = layer_ent;
+    client_2.layer.0 = layer_ent;
     client_2.visible_chunk_layer.0 = layer_ent;
     client_2.visible_entity_layers.0.insert(layer_ent);
 


### PR DESCRIPTION
# Objective

- Closes #96 
- Migrate entity bundles to required components

# Solution

- Changed the entity build.rs to build up requires tags for every step in the inheritence tree, so LivingEnitity now requires certain elements, MobEntity requires livingentity and everything it adds, etc.
- This required some changes to the client bundle to overwrite some of the things which were previously from the playerbundle. This will become cleaner once ClientBundle is also migrated to required components since it's then up to the caller to decide what components overwrite instead of having it in the bundle.