### PR TITLE
Send respawn packet before new chunks are sent

### DIFF
--- a/crates/chunkedge_server/src/client.rs
+++ b/crates/chunkedge_server/src/client.rs
@@ -82,7 +82,7 @@ impl Plugin for ClientPlugin {
                         .after(handle_layer_messages),
                     cleanup_chunks_after_client_despawn.after(update_view_and_layers),
                     crate::spawn::update_respawn_position.after(update_view_and_layers),
-                    crate::spawn::respawn.after(crate::spawn::update_respawn_position),
+                    crate::spawn::respawn.before(update_view_and_layers),
                     update_old_view_dist.after(update_view_and_layers),
                     update_game_mode,
                     update_food_saturation_health,
@@ -912,8 +912,8 @@ fn handle_layer_messages(
     );
 }
 
-/// This message will be emitted when a entity is unloaded for a client (e.g when
-/// moving out of range of the entity).
+/// This message will be emitted when a entity is unloaded for a client (e.g
+/// when moving out of range of the entity).
 #[derive(Debug, Clone, PartialEq, Message)]
 pub struct UnloadEntityForClientMessage {
     /// The client to unload the entity for.

--- a/crates/chunkedge_server/src/client.rs
+++ b/crates/chunkedge_server/src/client.rs
@@ -912,8 +912,8 @@ fn handle_layer_messages(
     );
 }
 
-/// This message will be emitted when a entity is unloaded for a client (e.g
-/// when moving out of range of the entity).
+/// This message will be emitted when a entity is unloaded for a client (e.g when
+/// moving out of range of the entity).
 #[derive(Debug, Clone, PartialEq, Message)]
 pub struct UnloadEntityForClientMessage {
     /// The client to unload the entity for.

--- a/src/tests/layer.rs
+++ b/src/tests/layer.rs
@@ -1,19 +1,64 @@
 use std::collections::BTreeSet;
 
 use bevy_ecs::world::EntityWorldMut;
+use chunkedge_ident::ident;
+use chunkedge_registry::{BiomeRegistry, DimensionTypeRegistry};
+use chunkedge_server::ChunkPos;
 
-use crate::client::{ViewDistance, VisibleEntityLayers};
+use crate::client::{ViewDistance, VisibleChunkLayer, VisibleEntityLayers};
 use crate::entity::cow::CowEntity;
 use crate::entity::{EntityLayerId, Position};
 use crate::layer::chunk::UnloadedChunk;
 use crate::layer::{ChunkLayer, EntityLayer};
 use crate::protocol::packets::play::{
     AddEntityS2c, BlockEntityDataS2c, ForgetLevelChunkS2c, LevelChunkWithLightS2c,
-    MoveEntityPosS2c, RemoveEntitiesS2c, SectionBlocksUpdateS2c,
+    MoveEntityPosS2c, RemoveEntitiesS2c, RespawnS2c, SectionBlocksUpdateS2c,
 };
 use crate::protocol::Packet;
 use crate::testing::ScenarioSingleClient;
 use crate::{BlockState, ChunkView, Despawned, Server};
+
+#[test]
+fn chunk_layer_switching() {
+    let ScenarioSingleClient {
+        mut app,
+        client: client_ent,
+        mut helper,
+        ..
+    } = ScenarioSingleClient::new();
+
+    let mut chunk_layer = ChunkLayer::new(
+        ident!("overworld"),
+        app.world().resource::<DimensionTypeRegistry>(),
+        app.world().resource::<BiomeRegistry>(),
+        app.world().resource::<Server>(),
+    );
+    chunk_layer.insert_chunk(ChunkPos::new(0, 0), UnloadedChunk::default());
+    let entity_layer = EntityLayer::new(app.world().resource::<Server>());
+    let dest_layer = app.world_mut().spawn((chunk_layer, entity_layer)).id();
+
+    // Let the destination layer initialize, then discard the join traffic.
+    app.update();
+    helper.collect_received();
+
+    // Move the client into the destination layer.
+    let mut client = app.world_mut().entity_mut(client_ent);
+    client.get_mut::<EntityLayerId>().unwrap().0 = dest_layer;
+    client.get_mut::<VisibleChunkLayer>().unwrap().0 = dest_layer;
+    let mut vel = client.get_mut::<VisibleEntityLayers>().unwrap();
+    vel.0.clear();
+    vel.0.insert(dest_layer);
+
+    app.update();
+
+    let recvd = helper.collect_received();
+
+    // The respawn packet clears the client's chunk cache, so it must be sent
+    // before the new chunks are sent.
+    recvd.assert_count::<RespawnS2c>(1);
+    recvd.assert_count::<LevelChunkWithLightS2c>(1);
+    recvd.assert_order::<(RespawnS2c, LevelChunkWithLightS2c)>();
+}
 
 #[test]
 fn block_create_destroy() {


### PR DESCRIPTION
### Objective

Currently, when the client is switched to a new chunk layer, the respawn packet is sent _after_ the new chunks are sent. The respawn packet makes the client drop its chunk cache, which drops all the chunks it just received.

The result is that the client doesn't see any chunks after a chunk layer change.

### The fix

The fix is to send the respawn packet _before_ the new chunks are sent to invalidate old chunks and keep the new chunks.

### Testing

I tested this in-game via my own private project and it works.